### PR TITLE
Fix never use default local repository root issue

### DIFF
--- a/git.go
+++ b/git.go
@@ -17,7 +17,12 @@ func GitConfigAll(key string) ([]string, error) {
 		return nil, err
 	}
 
-	return strings.Split(value, "\000"), nil
+	var values = strings.Split(value, "\000")
+	if len(values) == 1 && values[0] == "" {
+		values = values[:0]
+	}
+
+	return values, nil
 }
 
 func gitConfig(key string, all bool) (string, error) {


### PR DESCRIPTION
`strings.Split(value, "\000")` returns array with empty string (`[""]`) when key not found in gitconfig.

`localRepositoryRoots` check gitconfig `ghq.root` then compare result array length with 0, but it's length never be 0 now.

``` go
    _localRepositoryRoots, err = GitConfigAll("ghq.root")
    utils.PanicIf(err)

    if len(_localRepositoryRoots) == 0 {
        usr, err := user.Current()
        utils.PanicIf(err)

        _localRepositoryRoots = []string{path.Join(usr.HomeDir, ".ghq")}
    }
```

 (at https://github.com/motemen/ghq/blob/master/local_repository.go#L163)

I try `ghq get motemen/ghq` without `ghq.root` setting then clone repository to `~/github.com/motemen/ghq` because never use default setting `~/.ghq`.

Thank you.
