### PR TITLE
Exit when VCS is not found

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -197,7 +197,14 @@ func getRemoteRepository(remote RemoteRepository, doUpdate bool) {
 
 	if newPath {
 		utils.Log("clone", fmt.Sprintf("%s -> %s", remoteURL, path))
-		remote.VCS().Clone(remoteURL, path)
+
+		vcs := remote.VCS()
+		if vcs == nil {
+			utils.Log("error", fmt.Sprintf("Counld not found version control system: %s", remoteURL))
+			os.Exit(1)
+		}
+
+		vcs.Clone(remoteURL, path)
 	} else {
 		if doUpdate {
 			utils.Log("update", path)


### PR DESCRIPTION
If VCS is not found, program will down with panic. It should catch it and tell user reason.
