### PR TITLE
remove port number in local repository path

### DIFF
--- a/local_repository.go
+++ b/local_repository.go
@@ -44,7 +44,7 @@ func LocalRepositoryFromFullPath(fullPath string) (*LocalRepository, error) {
 
 func LocalRepositoryFromURL(remoteURL *url.URL) *LocalRepository {
 	pathParts := append(
-		[]string{remoteURL.Host}, strings.Split(remoteURL.Path, "/")...,
+		[]string{strings.Split(remoteURL.Host, ":")[0]}, strings.Split(remoteURL.Path, "/")...,
 	)
 	relPath := strings.TrimSuffix(path.Join(pathParts...), ".git")
 

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -26,4 +26,8 @@ func TestNewLocalRepository(t *testing.T) {
 	stashURL, _ := url.Parse("ssh://git@stash.com/scm/motemen/ghq")
 	r = LocalRepositoryFromURL(stashURL)
 	Expect(r.FullPath).To(Equal("/repos/stash.com/scm/motemen/ghq"))
+
+	stashURLWithPort, _ := url.Parse("ssh://git@stash.com:7999/scm/motemen/ghq")
+	r = LocalRepositoryFromURL(stashURLWithPort)
+	Expect(r.FullPath).To(Equal("/repos/stash.com/scm/motemen/ghq"))
 }


### PR DESCRIPTION
I'd like to change local repository path because if there is a colon `:` in the path, [Bundler](http://bundler.io/) doesn't work.

before

```
/repos/stash.com:7999/scm/motemen/ghq
```

after

```
/repos/stash.com/scm/motemen/ghq
```
