### PR TITLE
Add root command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -19,6 +19,7 @@ var Commands = []cli.Command{
 	commandList,
 	commandLook,
 	commandImport,
+	commandRoot,
 }
 
 var commandGet = cli.Command{
@@ -71,6 +72,12 @@ var commandImport = cli.Command{
 	Action: doImport,
 }
 
+var commandRoot = cli.Command{
+	Name:   "root",
+	Usage:  "Returns repositories' root",
+	Action: doRoot,
+}
+
 type commandDoc struct {
 	Parent    string
 	Arguments string
@@ -81,6 +88,7 @@ var commandDocs = map[string]commandDoc{
 	"list":   {"", "[-p] [-e] [<query>]"},
 	"look":   {"", "<project> | <user>/<project> | <host>/<user>/<project>"},
 	"import": {"", "< file"},
+	"root":   {"", ""},
 }
 
 // Makes template conditionals to generate per-command documents.
@@ -339,4 +347,8 @@ func doImport(c *cli.Context) {
 		utils.Log("error", fmt.Sprintf("While reading input: %s", err))
 		os.Exit(1)
 	}
+}
+
+func doRoot(c *cli.Context) {
+	fmt.Println(primaryLocalRepositoryRoot())
 }


### PR DESCRIPTION
I'm glad ghq returns its' root path by itself.

Here is an use case.

``` sh
    local ghq_root_dir=$(git config ghq.root || echo ~/.ghq)
```

I prefer like this instead.

``` sh
    local ghq_root_dir=$(ghq root)
```

Thanks,
