### PR TITLE
accept SCP-like URL (git@github.com) for import command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -311,7 +310,7 @@ func doImport(c *cli.Context) {
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		line := scanner.Text()
-		url, err := url.Parse(line)
+		url, err := NewURL(line)
 		if err != nil {
 			utils.Log("error", fmt.Sprintf("Could not parse URL <%s>: %s", line, err))
 			continue


### PR DESCRIPTION
- `url.Parse` doesn't handle SCP-like URL (e.g. git@github.com) properly.

```
fatal: invalid URL scheme name or missing '://' suffix
     error exit status 128
```
- now, `ghq import < FILE` clones repos into `.ghq/git@github.com:user/repo`.
- substituted `url.Parse` with `NewURL`, which accepts SCP-like URL as `doGet` currently implemented.
