### PR TITLE
Include zsh completion into release zip files

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -18,7 +18,7 @@ build:
     - script:
         name: goxc build & archive
         code: |
-          goxc -tasks='xc archive' -bc 'linux,!arm windows darwin' -d $WERCKER_OUTPUT_DIR/ -build-ldflags "-X main.Version \"$(git describe --tags --always --dirty) ($(git name-rev --name-only HEAD | sed 's/^remotes\/origin\///'))\"" -resources-include='README*'
+          goxc -tasks='xc archive' -bc 'linux,!arm windows darwin' -d $WERCKER_OUTPUT_DIR/ -build-ldflags "-X main.Version \"$(git describe --tags --always --dirty) ($(git name-rev --name-only HEAD | sed 's/^remotes\/origin\///'))\"" -resources-include='README*,zsh/_ghq'
     - script:
         name: output release tag
         code: |


### PR DESCRIPTION
I would like to install `ghq` **with its zsh completion** via Homebrew, and I meant it in motemen/homebrew-ghq#4.
But for now it works only when installed with `--HEAD` option.

I think that including zsh completion into release zip files enables it to be installed without `--HEAD` option.
