### PR TITLE
Return exit status 1 for clone failure

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -183,7 +183,11 @@ func getRemoteRepository(remote RemoteRepository, doUpdate bool, isShallow bool)
 			os.Exit(1)
 		}
 
-		vcs.Clone(remoteURL, path, isShallow)
+		err := vcs.Clone(remoteURL, path, isShallow)
+		if err != nil {
+			utils.Log("error", fmt.Sprintf("Could not find repository: %s", err))
+			os.Exit(1)
+		}
 	} else {
 		if doUpdate {
 			utils.Log("update", path)


### PR DESCRIPTION
I want to write a script which switches its behavior depending on `ghq get`'s result.
But currently `ghq get` returns 0 even if it fails. So I changed the exit status to 1.
## before

```
$ ghq get foo/bar; echo $?
     clone https://github.com/foo/bar -> /Users/k0kubun/src/github.com/foo/bar
       git clone https://github.com/foo/bar /Users/k0kubun/src/github.com/foo/bar
Cloning into '/Users/k0kubun/src/github.com/foo/bar'...
remote: Repository not found.
fatal: repository 'https://github.com/foo/bar/' not found
0
```
## after

```
$ ghq get foo/bar; echo $?
     clone https://github.com/foo/bar -> /Users/k0kubun/src/github.com/foo/bar
       git clone https://github.com/foo/bar /Users/k0kubun/src/github.com/foo/bar
Cloning into '/Users/k0kubun/src/github.com/foo/bar'...
remote: Repository not found.
fatal: repository 'https://github.com/foo/bar/' not found
     error Could not find repository: /usr/bin/git: exit status 128
1
```
