### PR TITLE
Add option --ignore-case to list

### DIFF
--- a/cmd_list.go
+++ b/cmd_list.go
@@ -14,10 +14,15 @@ func doList(c *cli.Context) error {
 		w                = c.App.Writer
 		query            = c.Args().First()
 		exact            = c.Bool("exact")
+		ignoreCase       = c.Bool("ignore-case")
 		vcsBackend       = c.String("vcs")
 		printFullPaths   = c.Bool("full-path")
 		printUniquePaths = c.Bool("unique")
 	)
+
+	if exact && ignoreCase {
+		return fmt.Errorf("options -e(--exact) and -i(--ignore-case) are mutually exclusive")
+	}
 
 	filterByQuery := func(_ *LocalRepository) bool {
 		return true
@@ -43,7 +48,13 @@ func doList(c *cli.Context) error {
 				host = paths[0]
 			}
 			filterByQuery = func(repo *LocalRepository) bool {
-				return strings.Contains(repo.NonHostPath(), query) &&
+				p := repo.NonHostPath()
+				q := query
+				if ignoreCase {
+					p = strings.ToLower(p)
+					q = strings.ToLower(q)
+				}
+				return strings.Contains(p, q) &&
 					(host == "" || repo.PathParts[0] == host)
 			}
 		}

--- a/cmd_list_test.go
+++ b/cmd_list_test.go
@@ -132,6 +132,10 @@ func TestDoList_query(t *testing.T) {
 		name:   "vcs",
 		args:   []string{"--vcs", "svn"},
 		expect: "github.com/msh5/svntest\n",
+	}, {
+		name:   "ignore case",
+		args:   []string{"-ignore-case", "songmu"},
+		expect: "github.com/Songmu/gobump\n",
 	}}
 
 	withFakeGitBackend(t, func(t *testing.T, tmproot string, _ *_cloneArgs, _ *_updateArgs) {

--- a/commands.go
+++ b/commands.go
@@ -46,13 +46,15 @@ var commandList = &cli.Command{
     repositories whose names contain that query text are listed.
     '-e' ('--exact') forces the match to be an exact one (i.e. the query equals to
     project or user/project) If '-p' ('--full-path') is given, the full paths
-    to the repository root are printed instead of relative ones.`,
+    to the repository root are printed instead of relative ones.
+    '-i' ('--ignore-case') performs case-insensitive matching.`,
 	Action: doList,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{Name: "exact", Aliases: []string{"e"}, Usage: "Perform an exact match"},
 		&cli.StringFlag{Name: "vcs", Usage: "Specify `vcs` backend for matching"},
 		&cli.BoolFlag{Name: "full-path", Aliases: []string{"p"}, Usage: "Print full paths"},
 		&cli.BoolFlag{Name: "unique", Usage: "Print unique subpaths"},
+		&cli.BoolFlag{Name: "ignore-case", Aliases: []string{"i"}, Usage: "Perform case-insensitive matching"},
 	},
 }
 
@@ -81,7 +83,7 @@ type commandDoc struct {
 
 var commandDocs = map[string]commandDoc{
 	"get":    {"", "[-u] [-p] [--shallow] [--vcs <vcs>] [--look] [--silent] [--brach <branch>] [--no-recursive] <repository URL>|<project>|<user>/<project>|<host>/<user>/<project>"},
-	"list":   {"", "[-p] [-e] [<query>]"},
+	"list":   {"", "[-p] [-e] [-i] [<query>]"},
 	"create": {"", "<project>|<user>/<project>|<host>/<user>/<project>"},
 	"root":   {"", "[-all]"},
 }

--- a/misc/zsh/_ghq
+++ b/misc/zsh/_ghq
@@ -35,6 +35,7 @@ function _ghq () {
                         '--vcs[Specify vcs backend for matching]' \
                         '(-p --full-path)'{-p,--full-path}'[Print full paths]' \
                         '--unique[Print unique subpaths]' \
+                        '(-i --ignore-case)'{-i,--ignore-case}'[Perform case-insensitive match]' \
                         '(-)*:: :->null_state' \
                         && ret=0
                     ;;


### PR DESCRIPTION
Adds an option `--ignore-case` to `ghq list`, which enables case-insensitive search.
This is useful especially when searching repos which names include upper-case letters.
(For example, projects written in perl often have repo names like 'p5-My-Foo-Module')