### PR TITLE
Refactor so that RemoteRepository#VCS can return an error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /ghq
 /ghq.exe
 /dist
+.vscode
+.idea

--- a/cmd_create.go
+++ b/cmd_create.go
@@ -35,12 +35,15 @@ func doCreate(c *cli.Context) error {
 
 	remoteRepo, err := NewRemoteRepository(u)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	vcsBackend, ok := vcsRegistry[vcs]
 	if !ok {
-		vcsBackend, u = remoteRepo.VCS()
+		vcsBackend, _, err = remoteRepo.VCS()
+		if err != nil {
+			return err
+		}
 	}
 	if vcsBackend == nil {
 		return fmt.Errorf("failed to init: unsupported VCS")

--- a/getter.go
+++ b/getter.go
@@ -79,9 +79,9 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 		)
 		vcs, ok := vcsRegistry[g.vcs]
 		if !ok {
-			vcs, repoURL = remote.VCS()
-			if vcs == nil {
-				return fmt.Errorf("Could not find version control system: %s", remoteURL)
+			vcs, repoURL, err = remote.VCS()
+			if err != nil {
+				return err
 			}
 		}
 		l := detectLocalRepoRoot(

--- a/remote_repository.go
+++ b/remote_repository.go
@@ -34,6 +34,7 @@ func (repo *GitHubRepository) URL() *url.URL {
 // IsValid determine if the repository is valid or not
 func (repo *GitHubRepository) IsValid() bool {
 	if strings.HasPrefix(repo.url.Path, "/blog/") {
+		logger.Log("github", `the user or organization named "blog" is invalid on github, "https://github.com/blog" is redirected to "https://github.blog".`)
 		return false
 	}
 	pathComponents := strings.Split(strings.Trim(repo.url.Path, "/"), "/")

--- a/remote_repository.go
+++ b/remote_repository.go
@@ -21,7 +21,7 @@ type RemoteRepository interface {
 	VCS() (*VCSBackend, *url.URL, error)
 }
 
-// A GitHubRepository represents a GitHub repository. Impliments RemoteRepository.
+// A GitHubRepository represents a GitHub repository. Implements RemoteRepository.
 type GitHubRepository struct {
 	url *url.URL
 }
@@ -69,7 +69,7 @@ func (repo *GitHubGistRepository) URL() *url.URL {
 	return repo.url
 }
 
-// IsValid determin if the gist rpository is valid or not
+// IsValid determine if the gist rpository is valid or not
 func (repo *GitHubGistRepository) IsValid() bool {
 	return true
 }
@@ -89,7 +89,7 @@ func (repo *DarksHubRepository) URL() *url.URL {
 	return repo.url
 }
 
-// IsValid determine if the darcshub repositroy is valid or not
+// IsValid determine if the darcshub repository is valid or not
 func (repo *DarksHubRepository) IsValid() bool {
 	return strings.Count(repo.url.Path, "/") == 2
 }
@@ -183,7 +183,7 @@ func NewRemoteRepository(u *url.URL) (RemoteRepository, error) {
 		}
 	}()
 	if !repo.IsValid() {
-		return nil, fmt.Errorf("Not a valid repository: %s", u)
+		return nil, fmt.Errorf("not a valid repository: %s", u)
 	}
 	return repo, nil
 }

--- a/remote_repository.go
+++ b/remote_repository.go
@@ -165,7 +165,7 @@ func (repo *OtherRepository) VCS() (*VCSBackend, *url.URL, error) {
 		return SubversionBackend, repo.URL(), nil
 	}
 
-	return nil, nil, fmt.Errorf("cannont detect vcs, url=%s: %w", repo.URL(), err)
+	return nil, nil, fmt.Errorf("unsupported VCS, url=%s: %w", repo.URL(), err)
 }
 
 // NewRemoteRepository returns new RemoteRepository object from URL

--- a/remote_repository_test.go
+++ b/remote_repository_test.go
@@ -24,10 +24,6 @@ func TestNewRemoteRepository(t *testing.T) {
 		vcsBackend: GitBackend,
 		repoURL:    "https://github.com/motemen/ghq",
 	}, {
-		url:        "https://example.com/motemen/pusheen-explorer/",
-		valid:      true,
-		vcsBackend: nil,
-	}, {
 		url:        "https://gist.github.com/motemen/9733745",
 		valid:      true,
 		vcsBackend: GitBackend,
@@ -50,7 +46,7 @@ func TestNewRemoteRepository(t *testing.T) {
 			if repo.IsValid() != tc.valid {
 				t.Errorf("repo.IsValid() should be %v, but %v", tc.valid, repo.IsValid())
 			}
-			vcs, u := repo.VCS()
+			vcs, u, err := repo.VCS()
 			if vcs != tc.vcsBackend {
 				t.Errorf("got: %+v, expect: %+v", vcs, tc.vcsBackend)
 			}
@@ -58,6 +54,61 @@ func TestNewRemoteRepository(t *testing.T) {
 				if u.String() != tc.repoURL {
 					t.Errorf("repoURL: got: %s, expect: %s", u.String(), tc.repoURL)
 				}
+			}
+		})
+	}
+}
+
+func TestNewRemoteRepository_vcs_error(t *testing.T) {
+	testCases := []struct {
+		url        string
+		valid      bool
+		vcsBackend *VCSBackend
+		repoURL    string
+	}{{
+		url:        "https://example.com/motemen/pusheen-explorer/",
+		valid:      true,
+		vcsBackend: nil,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.url, func(t *testing.T) {
+			repo, err := NewRemoteRepository(mustParseURL(tc.url))
+			if err != nil {
+				t.Errorf("error should be nil but: %s", err)
+			}
+			if repo.IsValid() != tc.valid {
+				t.Errorf("repo.IsValid() should be %v, but %v", tc.valid, repo.IsValid())
+			}
+			vcs, u, err := repo.VCS()
+			if err == nil {
+				t.Fatalf("error should be nil but: %s", err)
+			}
+			if vcs != tc.vcsBackend {
+				t.Errorf("got: %+v, expect: %+v", vcs, tc.vcsBackend)
+			}
+			if u != nil {
+				t.Errorf("u should be nil: %s", u.String())
+			}
+		})
+	}
+}
+
+func TestNewRemoteRepository_error(t *testing.T) {
+	testCases := []struct {
+		url string
+	}{{
+		url: "https://github.com/blog/github",
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.url, func(t *testing.T) {
+			repo, err := NewRemoteRepository(mustParseURL(tc.url))
+			if err == nil {
+				t.Errorf("error should be nil but: %s", err)
+			}
+			if repo != nil {
+				t.Errorf("repo should be nil: %v", repo)
 			}
 		})
 	}

--- a/remote_repository_test.go
+++ b/remote_repository_test.go
@@ -24,6 +24,10 @@ func TestNewRemoteRepository(t *testing.T) {
 		vcsBackend: GitBackend,
 		repoURL:    "https://github.com/motemen/ghq",
 	}, {
+		url:        "https://example.com/motemen/pusheen-explorer/",
+		valid:      true,
+		vcsBackend: nil,
+	}, {
 		url:        "https://gist.github.com/motemen/9733745",
 		valid:      true,
 		vcsBackend: GitBackend,


### PR DESCRIPTION
Thanks for the great tool `ghq`.
I use `ghq` frequently.

related #282 

RemoteRepository's VCS methods cannot return an error.
So there is a potential issues such as #281.
I also found and fixed a bug  `ghq create github.com/blog/johejo` would create a directory despite an invalid github URL.