### PR TITLE
Fetch instead of pull if the working tree isn't tracking remote.

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -75,33 +75,20 @@ var GitBackend = &VCSBackend{
 		if _, err := os.Stat(filepath.Join(vg.dir, ".git/svn")); err == nil {
 			return GitsvnBackend.Update(vg)
 		}
-		var isTracking = func() (bool, error) {
-			buf := &bytes.Buffer{}
-			cmd := exec.Command("git", "status", "-b", "--porcelain")
-			cmd.Stdout = buf
-			cmd.Stderr = ioutil.Discard
-			cmd.Dir = vg.dir
-			err := cmdutil.RunCommand(cmd, true)
-			branch := strings.Split(buf.String(), "\n")[0]
-			return strings.Contains(branch, "..."), err
-		}
-		pull, err := isTracking()
+		err := runInDir(true)(vg.dir, "git", "rev-parse", "@{upstream}")
 		if err != nil {
-			return err
-		}
-		if pull {
-			err := runInDir(vg.silent)(vg.dir, "git", "pull", "--ff-only")
-			if err != nil {
-				return err
-			}
-			if vg.recursive {
-				return runInDir(vg.silent)(vg.dir, "git", "submodule", "update", "--init", "--recursive")
-			}
-		} else {
 			err := runInDir(vg.silent)(vg.dir, "git", "fetch")
 			if err != nil {
 				return err
 			}
+			return nil
+		}
+		err = runInDir(vg.silent)(vg.dir, "git", "pull", "--ff-only")
+		if err != nil {
+			return err
+		}
+		if vg.recursive {
+			return runInDir(vg.silent)(vg.dir, "git", "submodule", "update", "--init", "--recursive")
 		}
 		return nil
 	},

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -12,12 +12,8 @@ import (
 )
 
 var (
-	remoteDummyURL           = mustParseURL("https://example.com/git/repo")
-	dummyGitStatusWithRemote = []byte(`## master...origin/master
-`)
-	dummyGitStatus = []byte(`## master
-`)
-	dummySvnInfo = []byte(`Path: trunk
+	remoteDummyURL = mustParseURL("https://example.com/git/repo")
+	dummySvnInfo   = []byte(`Path: trunk
 URL: https://svn.apache.org/repos/asf/subversion/trunk
 Relative URL: ^/subversion/trunk
 Repository Root: https://svn.apache.org/repos/asf
@@ -90,9 +86,6 @@ func TestVCSBackend(t *testing.T) {
 			}(cmdutil.CommandRunner)
 			cmdutil.CommandRunner = func(cmd *exec.Cmd) error {
 				_commands = append(_commands, cmd)
-				if reflect.DeepEqual(cmd.Args, []string{"git", "status", "-b", "--porcelain"}) {
-					cmd.Stdout.Write(dummyGitStatusWithRemote)
-				}
 				return nil
 			}
 			return GitBackend.Update(&vcsGetOption{
@@ -109,8 +102,8 @@ func TestVCSBackend(t *testing.T) {
 			}(cmdutil.CommandRunner)
 			cmdutil.CommandRunner = func(cmd *exec.Cmd) error {
 				_commands = append(_commands, cmd)
-				if reflect.DeepEqual(cmd.Args, []string{"git", "status", "-b", "--porcelain"}) {
-					cmd.Stdout.Write(dummyGitStatus)
+				if reflect.DeepEqual(cmd.Args, []string{"git", "rev-parse", "@{upstream}"}) {
+					return fmt.Errorf("[test] failed to git rev-parse @{upstream}")
 				}
 				return nil
 			}
@@ -138,9 +131,6 @@ func TestVCSBackend(t *testing.T) {
 			}(cmdutil.CommandRunner)
 			cmdutil.CommandRunner = func(cmd *exec.Cmd) error {
 				_commands = append(_commands, cmd)
-				if reflect.DeepEqual(cmd.Args, []string{"git", "status", "-b", "--porcelain"}) {
-					cmd.Stdout.Write(dummyGitStatusWithRemote)
-				}
 				return nil
 			}
 			return GitBackend.Update(&vcsGetOption{

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -81,13 +81,6 @@ func TestVCSBackend(t *testing.T) {
 	}, {
 		name: "[git] update",
 		f: func() error {
-			defer func(orig func(cmd *exec.Cmd) error) {
-				cmdutil.CommandRunner = orig
-			}(cmdutil.CommandRunner)
-			cmdutil.CommandRunner = func(cmd *exec.Cmd) error {
-				_commands = append(_commands, cmd)
-				return nil
-			}
 			return GitBackend.Update(&vcsGetOption{
 				dir: localDir,
 			})
@@ -126,13 +119,6 @@ func TestVCSBackend(t *testing.T) {
 	}, {
 		name: "[git] update recursive",
 		f: func() error {
-			defer func(orig func(cmd *exec.Cmd) error) {
-				cmdutil.CommandRunner = orig
-			}(cmdutil.CommandRunner)
-			cmdutil.CommandRunner = func(cmd *exec.Cmd) error {
-				_commands = append(_commands, cmd)
-				return nil
-			}
 			return GitBackend.Update(&vcsGetOption{
 				dir:       localDir,
 				recursive: true,


### PR DESCRIPTION
# Problem

I'm using ghq on a git repository. ghq get -u gives an error when I'm on a branch that has not been pushed to the remote.

# Proposal

Invoke git fetch instead of git pull in such situation.

# How to reproduce

```
~/ghq/github.com/x-motemen/ghq% git checkout -b local-branch
Switched to a new branch 'local-branch'
~/ghq/github.com/x-motemen/ghq% ghq get -u github.com/x-motemen/ghq
    update /Users/yoichi/ghq/github.com/x-motemen/ghq
       git pull --ff-only
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>

If you wish to set tracking information for this branch you can do so with:

    git branch --set-upstream-to=<remote>/<branch> local-branch

     error failed to get "github.com/x-motemen/ghq": /usr/local/bin/git: exit status 1
```