### PR TITLE
Care the some repository URL ended with '.git/'

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -85,8 +85,8 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 			}
 		}
 		l := detectLocalRepoRoot(
-			remoteURL.Path,
-			strings.TrimSuffix(strings.TrimSuffix(repoURL.Path, "/"), ".git"))
+			strings.TrimSuffix(remoteURL.Path, ".git"),
+			strings.TrimSuffix(repoURL.Path, ".git"))
 		if l != "" {
 			localRepoRoot = filepath.Join(local.RootPath, remoteURL.Hostname(), l)
 		}

--- a/getter.go
+++ b/getter.go
@@ -85,8 +85,8 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 			}
 		}
 		l := detectLocalRepoRoot(
-			strings.TrimSuffix(remoteURL.Path, ".git"),
-			strings.TrimSuffix(repoURL.Path, ".git"))
+			remoteURL.Path,
+			repoURL.Path)
 		if l != "" {
 			localRepoRoot = filepath.Join(local.RootPath, remoteURL.Hostname(), l)
 		}
@@ -122,6 +122,8 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 }
 
 func detectLocalRepoRoot(remotePath, repoPath string) string {
+	remotePath = strings.TrimSuffix(remotePath, ".git")
+	repoPath = strings.TrimSuffix(repoPath, ".git")
 	pathParts := strings.Split(repoPath, "/")
 	pathParts = pathParts[1:]
 	for i := 0; i < len(pathParts); i++ {

--- a/getter.go
+++ b/getter.go
@@ -85,8 +85,8 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 			}
 		}
 		l := detectLocalRepoRoot(
-			strings.TrimSuffix(remoteURL.Path, ".git"),
-			strings.TrimSuffix(repoURL.Path, ".git"))
+			remoteURL.Path,
+			strings.TrimSuffix(strings.TrimSuffix(repoURL.Path, "/"), ".git"))
 		if l != "" {
 			localRepoRoot = filepath.Join(local.RootPath, remoteURL.Hostname(), l)
 		}

--- a/getter.go
+++ b/getter.go
@@ -122,8 +122,8 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 }
 
 func detectLocalRepoRoot(remotePath, repoPath string) string {
-	remotePath = strings.TrimSuffix(remotePath, ".git")
-	repoPath = strings.TrimSuffix(repoPath, ".git")
+	remotePath = strings.TrimSuffix(strings.TrimSuffix(remotePath, "/"), ".git")
+	repoPath = strings.TrimSuffix(strings.TrimSuffix(repoPath, "/"), ".git")
 	pathParts := strings.Split(repoPath, "/")
 	pathParts = pathParts[1:]
 	for i := 0; i < len(pathParts); i++ {

--- a/getter_test.go
+++ b/getter_test.go
@@ -45,6 +45,16 @@ func TestDetectLocalRepoRoot(t *testing.T) {
 		remotePath: "/path/to/repo.git",
 		repoPath:   "/path/to/repo.git",
 		expect:     "/path/to/repo",
+	}, {
+		name:       "trailing slash",
+		remotePath: "/path/to/repo/",
+		repoPath:   "/path/to/repo/",
+		expect:     "/path/to/repo",
+	}, {
+		name:       ".git/ at the end",
+		remotePath: "/path/to/repo.git/",
+		repoPath:   "/path/to/repo.git/",
+		expect:     "/path/to/repo",
 	}}
 
 	for _, tc := range testCases {

--- a/getter_test.go
+++ b/getter_test.go
@@ -40,6 +40,11 @@ func TestDetectLocalRepoRoot(t *testing.T) {
 		remotePath: "/zap/buffer",
 		repoPath:   "/uber-go/zap",
 		expect:     "/zap",
+	}, {
+		name:       ".git at the end",
+		remotePath: "/path/to/repo.git",
+		repoPath:   "/path/to/repo.git",
+		expect:     "/path/to/repo",
 	}}
 
 	for _, tc := range testCases {

--- a/getter_test.go
+++ b/getter_test.go
@@ -40,6 +40,21 @@ func TestDetectLocalRepoRoot(t *testing.T) {
 		remotePath: "/zap/buffer",
 		repoPath:   "/uber-go/zap",
 		expect:     "/zap",
+	}, {
+		name:       ".git at the end",
+		remotePath: "/path/to/repo.git",
+		repoPath:   "/path/to/repo",
+		expect:     "/path/to/repo",
+	}, {
+		name:       "trailing slash",
+		remotePath: "/path/to/repo/",
+		repoPath:   "/path/to/repo",
+		expect:     "/path/to/repo",
+	}, {
+		name:       ".git/ at the end",
+		remotePath: "/path/to/repo.git/",
+		repoPath:   "/path/to/repo",
+		expect:     "/path/to/repo",
 	}}
 
 	for _, tc := range testCases {

--- a/getter_test.go
+++ b/getter_test.go
@@ -40,21 +40,6 @@ func TestDetectLocalRepoRoot(t *testing.T) {
 		remotePath: "/zap/buffer",
 		repoPath:   "/uber-go/zap",
 		expect:     "/zap",
-	}, {
-		name:       ".git at the end",
-		remotePath: "/path/to/repo.git",
-		repoPath:   "/path/to/repo",
-		expect:     "/path/to/repo",
-	}, {
-		name:       "trailing slash",
-		remotePath: "/path/to/repo/",
-		repoPath:   "/path/to/repo",
-		expect:     "/path/to/repo",
-	}, {
-		name:       ".git/ at the end",
-		remotePath: "/path/to/repo.git/",
-		repoPath:   "/path/to/repo",
-		expect:     "/path/to/repo",
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
# Problem

1. ghq get https://git.kernel.org/pub/scm/git/git.git/
   -> GHQ_ROOT/git.kernel.org/pub/scm/git/git.git
2. ghq list | ghq get -u
   -> GHQ_ROOT/git.kernel.org/pub/scm/git/git

# Expected behavior

`ghq list | ghq get -u` updates existing local repository

# Proposal

Ignore trailing slash when stripping .git from the end

# Reference

`git clone` does strip trailing slash in its implementation
https://github.com/git/git/blob/101b3204f37606972b40fc17dec84560c22f69f6/builtin/clone.c#L241