### PR TITLE
Clone URLs by copying `net.URL` struct

### DIFF
--- a/go_import.go
+++ b/go_import.go
@@ -17,13 +17,7 @@ type metaImport struct {
 }
 
 func detectGoImport(u *url.URL) (string, *url.URL, error) {
-	goGetU := &url.URL{ // clone
-		Scheme:   u.Scheme,
-		User:     u.User,
-		Host:     u.Host,
-		Path:     u.Path,
-		RawQuery: u.RawQuery,
-	}
+	goGetU := *u
 	q := goGetU.Query()
 	q.Add("go-get", "1")
 	goGetU.RawQuery = q.Encode()

--- a/remote_repository.go
+++ b/remote_repository.go
@@ -43,21 +43,14 @@ func (repo *GitHubRepository) IsValid() bool {
 
 // VCS returns VCSBackend of the repository
 func (repo *GitHubRepository) VCS() (*VCSBackend, *url.URL, error) {
-	origU := repo.URL()
-	u := &url.URL{ // clone
-		Scheme:   origU.Scheme,
-		User:     origU.User,
-		Host:     origU.Host,
-		Path:     origU.Path,
-		RawQuery: origU.RawQuery,
-	}
+	u := *repo.url
 	pathComponents := strings.Split(strings.Trim(strings.TrimSuffix(u.Path, ".git"), "/"), "/")
 	path := "/" + strings.Join(pathComponents[0:2], "/")
 	if strings.HasSuffix(u.String(), ".git") {
 		path += ".git"
 	}
 	u.Path = path
-	return GitBackend, u, nil
+	return GitBackend, &u, nil
 }
 
 // A GitHubGistRepository represents a GitHub Gist repository.


### PR DESCRIPTION
According to https://github.com/golang/go/issues/38351 URLs could be safely duplicated by simply copying the underlying structure.