### PR TITLE
Add installation using asdf-vm

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -150,6 +150,13 @@ go get github.com/x-motemen/ghq
 conda install -c conda-forge go-ghq
 ----
 
+=== https://github.com/asdf-vm/asdf[asdf-vm]
+
+----
+asdf plugin add ghq
+asdf install ghq latest
+----
+
 === build
 
 ----


### PR DESCRIPTION
Now ghq is also available at asdf-vm plugin.
I add an instruction for using asdf-vm to install ghq in README.