### PR TITLE
Add installation instructions for GNU Guix

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -131,6 +131,12 @@ brew install ghq
 xbps-install -S ghq
 ----
 
+=== GNU Guix
+
+----
+guix install ghq
+----
+
 === Windows + scoop
 
 ----


### PR DESCRIPTION
A recipe for ghq 1.1.5 has been added to Guix in https://git.savannah.gnu.org/cgit/guix.git/commit/?id=2cb5ebf7a89b59e3e220b837202e4469e1db38c7.