### PR TITLE
~/.gitconfig incompatible with AWS CodeCommit region specific URL

### DIFF
--- a/local_repository.go
+++ b/local_repository.go
@@ -117,12 +117,15 @@ func LocalRepositoryFromURL(remoteURL *url.URL) (*LocalRepository, error) {
 
 func getRoot(u string) (string, error) {
 	prim := os.Getenv(envGhqRoot)
+	var err error
 	if prim != "" {
 		return prim, nil
 	}
-	prim, err := gitconfig.Do("--path", "--get-urlmatch", "ghq.root", u)
-	if err != nil && !gitconfig.IsNotFound(err) {
-		return "", err
+	if !codecommitLikeURLPattern.MatchString(u) {
+		prim, err = gitconfig.Do("--path", "--get-urlmatch", "ghq.root", u)
+		if err != nil && !gitconfig.IsNotFound(err) {
+			return "", err
+		}
 	}
 	if prim == "" {
 		prim, err = primaryLocalRepositoryRoot()


### PR DESCRIPTION
`ghq get codecommit::region://repository` is failed when a user uses ~/.gitconfig to configure `ghq`.

https://twitter.com/3socha/status/1396379504524726274

Because `git config --get-urlmatch` does not support schemes include ':' (colon).

SEE ALSO:
https://github.com/git/git/blob/master/urlmatch.c#L163