### PR TITLE
avoid using "Japanese Only"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -177,11 +177,14 @@ https://github.com/x-motemen/ghq/releases
 
 You can buy "ghq-handbook" from Leanpub for more detailed usage.
 
-https://leanpub.com/ghq-handbook (Currently Japanese Only)
+https://leanpub.com/ghq-handbook
 
 The source Markdown files of this book are also available for free from the following repository.
 
 https://github.com/Songmu/ghq-handbook
+
+Currently, only Japanese version available.
+Your translations are welcome!
 
 == AUTHOR
 


### PR DESCRIPTION
There is "Japanese Only" in the README. Some people might feel that it means "Japanese people only".
I guess It's not what you intended.

If you want to notify that "The article is written in Japanese",
you just use "Written in Japanese" or "only Japanese version available" or something else

ref. https://next49.hatenadiary.jp/entry/20140428/p1 (Written in Japanese)
ref. https://www.wdic.org/w/WDIC/Japanese+only (Written in Japanese)