### PR TITLE
update installation go

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -147,7 +147,7 @@ scoop install ghq
 === go get
 
 ----
-go get github.com/x-motemen/ghq
+go install github.com/x-motemen/ghq@latest
 ----
 
 === conda


### PR DESCRIPTION
when run command
`go get github.com/x-motemen/ghq`

this message is displayed.
```
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

 go get is [deprecated](https://golang.org/doc/go-get-install-deprecation) .

thank you.