### PR TITLE
fix: [trivial] fix the error message if nothing is passed to `ghq create`

### DIFF
--- a/cmd_create.go
+++ b/cmd_create.go
@@ -14,6 +14,11 @@ func doCreate(c *cli.Context) error {
 		vcs  = c.String("vcs")
 		w    = c.App.Writer
 	)
+
+	if name == "" {
+		return fmt.Errorf("repository name is required")
+	}
+
 	u, err := newURL(name, false, true)
 	if err != nil {
 		return err


### PR DESCRIPTION
The behavior and error message on `ghq create` (with no args) doesn't make sense. I've never seen that message before, in fact, but found it in making the pull-req https://github.com/x-motemen/ghq/pull/333. 

before:

```
$ ghq create
     error directory "/Users/goro-fuji/ghq/github.com/gfx" already exists and not empty
```

after:

```
$ ./ghq create
     error repository name is required
```
