### PR TITLE
bump the actions that run on Node.js 16 runtime

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -8,11 +8,11 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: setup go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: 1.x
     - name: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: install
       run: |
         GOBIN=$HOME/bin make install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: setup go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: 1.x
     - name: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: release
       env:
         GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,11 @@ jobs:
         - windows-latest
     steps:
     - name: setup go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: 1.x
     - name: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: lint
       run: |
         GO111MODULE=off GOBIN=$(pwd)/bin go get golang.org/x/lint/golint


### PR DESCRIPTION
actions/setup-go@v1 and actions/checkout@v1 run on Node.js 12 runtime, but Node.js 12 ends its support in the end of April 2022.
we should bump these actions to actions/setup-go@v3 and actions/checkout@v3 that run on Node.js 16 runtime.