### PR TITLE
Use t.Cleanup to remove temporally directories and set environment variables

### DIFF
--- a/cmd_create_test.go
+++ b/cmd_create_test.go
@@ -38,7 +38,7 @@ func TestDoCreate(t *testing.T) {
 		want      []string
 		wantDir   string
 		errStr    string
-		setup     func() func()
+		setup     func(t *testing.T)
 		cmdRun    func(cmd *exec.Cmd) error
 		skipOnWin bool
 	}{{
@@ -50,9 +50,8 @@ func TestDoCreate(t *testing.T) {
 		name:  "empty directory exists",
 		input: []string{"create", "motemen/ghqqq"},
 		want:  []string{"git", "init"},
-		setup: func() func() {
+		setup: func(t *testing.T) {
 			os.MkdirAll(filepath.Join(tmpd, "github.com/motemen/ghqqq"), 0755)
-			return func() {}
 		},
 		wantDir: filepath.Join(tmpd, "github.com/motemen/ghqqq"),
 	}, {
@@ -90,22 +89,19 @@ func TestDoCreate(t *testing.T) {
 	}, {
 		name:  "not permitted",
 		input: []string{"create", "motemen/ghq-notpermitted"},
-		setup: func() func() {
+		setup: func(t *testing.T) {
 			f := filepath.Join(tmpd, "github.com/motemen/ghq-notpermitted")
 			os.MkdirAll(f, 0)
-			return func() {
-				os.Chmod(f, 0755)
-			}
+			t.Cleanup(func() { os.Chmod(f, 0755) })
 		},
 		errStr:    "permission denied",
 		skipOnWin: true,
 	}, {
 		name:  "not empty",
 		input: []string{"create", "motemen/ghq-notempty"},
-		setup: func() func() {
+		setup: func(t *testing.T) {
 			f := filepath.Join(tmpd, "github.com/motemen/ghq-notempty", "dummy")
 			os.MkdirAll(f, 0755)
-			return func() {}
 		},
 		errStr: "already exists and not empty",
 	}}
@@ -117,8 +113,7 @@ func TestDoCreate(t *testing.T) {
 			}
 			lastCmd = nil
 			if tc.setup != nil {
-				teardown := tc.setup()
-				defer teardown()
+				tc.setup(t)
 			}
 
 			cmdutil.CommandRunner = commandRunner

--- a/cmd_create_test.go
+++ b/cmd_create_test.go
@@ -28,7 +28,7 @@ func TestDoCreate(t *testing.T) {
 	homeOnce = &sync.Once{}
 	tmpd := newTempDir(t)
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
-	defer tmpEnv(envGhqRoot, tmpd)()
+	setEnv(t, envGhqRoot, tmpd)
 	_localRepositoryRoots = nil
 	localRepoOnce = &sync.Once{}
 

--- a/cmd_create_test.go
+++ b/cmd_create_test.go
@@ -27,7 +27,6 @@ func TestDoCreate(t *testing.T) {
 	_home = ""
 	homeOnce = &sync.Once{}
 	tmpd := newTempDir(t)
-	defer os.RemoveAll(tmpd)
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
 	defer tmpEnv(envGhqRoot, tmpd)()
 	_localRepositoryRoots = nil

--- a/cmd_get_test.go
+++ b/cmd_get_test.go
@@ -173,10 +173,10 @@ func TestCommandGet(t *testing.T) {
 		name: "ghq.<url>.root",
 		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
 			tmpd := newTempDir(t)
-			defer gitconfig.WithConfig(t, fmt.Sprintf(`
+			t.Cleanup(gitconfig.WithConfig(t, fmt.Sprintf(`
 [ghq "https://github.com/motemen"]
   root = "%s"
-`, filepath.ToSlash(tmpd)))()
+`, filepath.ToSlash(tmpd))))
 			app.Run([]string{"", "get", "motemen/ghq-test-repo"})
 
 			localDir := filepath.Join(tmpd, "github.com", "motemen", "ghq-test-repo")

--- a/cmd_get_test.go
+++ b/cmd_get_test.go
@@ -173,7 +173,6 @@ func TestCommandGet(t *testing.T) {
 		name: "ghq.<url>.root",
 		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
 			tmpd := newTempDir(t)
-			defer os.RemoveAll(tmpd)
 			defer gitconfig.WithConfig(t, fmt.Sprintf(`
 [ghq "https://github.com/motemen"]
   root = "%s"

--- a/cmd_list_test.go
+++ b/cmd_list_test.go
@@ -192,9 +192,7 @@ func TestDoList_unique(t *testing.T) {
 	defer func(orig string) { os.Setenv(envGhqRoot, orig) }(os.Getenv(envGhqRoot))
 
 	tmp1 := newTempDir(t)
-	defer os.RemoveAll(tmp1)
 	tmp2 := newTempDir(t)
-	defer os.RemoveAll(tmp2)
 
 	_localRepositoryRoots = nil
 	localRepoOnce = &sync.Once{}
@@ -229,10 +227,7 @@ func TestDoList_notPermittedRoot(t *testing.T) {
 	}
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
 	tmpdir := newTempDir(t)
-	defer func(dir string) {
-		os.Chmod(dir, 0755)
-		os.RemoveAll(dir)
-	}(tmpdir)
+	defer os.Chmod(tmpdir, 0755)
 	defer tmpEnv(envGhqRoot, tmpdir)()
 
 	_localRepositoryRoots = nil
@@ -253,10 +248,7 @@ func TestDoList_withSystemHiddenDir(t *testing.T) {
 	tmpdir := newTempDir(t)
 	systemHidden := filepath.Join(tmpdir, ".system")
 	os.MkdirAll(systemHidden, 0000)
-	defer func(dir string) {
-		os.Chmod(systemHidden, 0755)
-		os.RemoveAll(dir)
-	}(tmpdir)
+	defer os.Chmod(systemHidden, 0755)
 	defer tmpEnv(envGhqRoot, tmpdir)()
 
 	_localRepositoryRoots = nil

--- a/cmd_list_test.go
+++ b/cmd_list_test.go
@@ -189,7 +189,6 @@ func TestDoList_query(t *testing.T) {
 
 func TestDoList_unique(t *testing.T) {
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
-	defer func(orig string) { os.Setenv(envGhqRoot, orig) }(os.Getenv(envGhqRoot))
 
 	tmp1 := newTempDir(t)
 	tmp2 := newTempDir(t)
@@ -197,7 +196,7 @@ func TestDoList_unique(t *testing.T) {
 	_localRepositoryRoots = nil
 	localRepoOnce = &sync.Once{}
 	rootPaths := []string{tmp1, tmp2}
-	os.Setenv(envGhqRoot, strings.Join(rootPaths, string(os.PathListSeparator)))
+	setEnv(t, envGhqRoot, strings.Join(rootPaths, string(os.PathListSeparator)))
 	for _, rootPath := range rootPaths {
 		os.MkdirAll(filepath.Join(rootPath, "github.com/motemen/ghq/.git"), 0755)
 	}
@@ -211,7 +210,7 @@ func TestDoList_unique(t *testing.T) {
 
 func TestDoList_unknownRoot(t *testing.T) {
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
-	defer tmpEnv(envGhqRoot, "/path/to/unknown-ghq")()
+	setEnv(t, envGhqRoot, "/path/to/unknown-ghq")
 	_localRepositoryRoots = nil
 	localRepoOnce = &sync.Once{}
 
@@ -228,7 +227,7 @@ func TestDoList_notPermittedRoot(t *testing.T) {
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
 	tmpdir := newTempDir(t)
 	defer os.Chmod(tmpdir, 0755)
-	defer tmpEnv(envGhqRoot, tmpdir)()
+	setEnv(t, envGhqRoot, tmpdir)
 
 	_localRepositoryRoots = nil
 	localRepoOnce = &sync.Once{}
@@ -249,7 +248,7 @@ func TestDoList_withSystemHiddenDir(t *testing.T) {
 	systemHidden := filepath.Join(tmpdir, ".system")
 	os.MkdirAll(systemHidden, 0000)
 	defer os.Chmod(systemHidden, 0755)
-	defer tmpEnv(envGhqRoot, tmpdir)()
+	setEnv(t, envGhqRoot, tmpdir)
 
 	_localRepositoryRoots = nil
 	localRepoOnce = &sync.Once{}

--- a/cmd_root_test.go
+++ b/cmd_root_test.go
@@ -43,24 +43,20 @@ func TestDoRoot(t *testing.T) {
 	}{{
 		name: "env",
 		setup: func(t *testing.T) {
-			orig := os.Getenv(envGhqRoot)
-			os.Setenv(envGhqRoot, "/path/to/ghqroot1"+string(os.PathListSeparator)+"/path/to/ghqroot2")
-			t.Cleanup(func() { os.Setenv(envGhqRoot, orig) })
+			setEnv(t, envGhqRoot, "/path/to/ghqroot1"+string(os.PathListSeparator)+"/path/to/ghqroot2")
 		},
 		expect:    "/path/to/ghqroot1\n",
 		allExpect: "/path/to/ghqroot1\n/path/to/ghqroot2\n",
 	}, {
 		name: "gitconfig",
 		setup: func(t *testing.T) {
-			orig := os.Getenv(envGhqRoot)
-			os.Setenv(envGhqRoot, "")
+			setEnv(t, envGhqRoot, "")
 			t.Cleanup(gitconfig.WithConfig(t, `
 [ghq]
   root = /path/to/ghqroot12
   root = /path/to/ghqroot12
   root = /path/to/ghqroot11
 `))
-			t.Cleanup(func() { os.Setenv(envGhqRoot, orig) })
 		},
 		expect:    "/path/to/ghqroot11\n",
 		allExpect: "/path/to/ghqroot11\n/path/to/ghqroot12\n",
@@ -75,9 +71,9 @@ func TestDoRoot(t *testing.T) {
 			}
 			f.Close()
 
-			t.Cleanup(tmpEnv(envGhqRoot, ""))
-			t.Cleanup(tmpEnv("GIT_CONFIG", fpath))
-			t.Cleanup(tmpEnv("HOME", "/path/to/ghqhome"))
+			setEnv(t, envGhqRoot, "")
+			setEnv(t, "GIT_CONFIG", fpath)
+			setEnv(t, "HOME", "/path/to/ghqhome")
 		},
 		expect:    "/path/to/ghqhome/ghq\n",
 		allExpect: "/path/to/ghqhome/ghq\n",

--- a/cmd_root_test.go
+++ b/cmd_root_test.go
@@ -83,7 +83,6 @@ func TestDoRoot(t *testing.T) {
 			restore3 := tmpEnv("HOME", "/path/to/ghqhome")
 
 			return func() {
-				os.RemoveAll(tmpd)
 				restore1()
 				restore2()
 				restore3()

--- a/commands_test.go
+++ b/commands_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/url"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -23,7 +22,6 @@ type _updateArgs struct {
 
 func withFakeGitBackend(t *testing.T, block func(*testing.T, string, *_cloneArgs, *_updateArgs)) {
 	tmpRoot := newTempDir(t)
-	defer os.RemoveAll(tmpRoot)
 
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
 	_localRepositoryRoots = []string{tmpRoot}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -121,15 +121,15 @@ func newTempDir(t *testing.T) string {
 	return s
 }
 
-func tmpEnv(key, val string) func() {
+func setEnv(t *testing.T, key, val string) {
 	orig, ok := os.LookupEnv(key)
 	os.Setenv(key, val)
 
-	return func() {
+	t.Cleanup(func() {
 		if ok {
 			os.Setenv(key, orig)
 		} else {
 			os.Unsetenv(key)
 		}
-	}
+	})
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -89,6 +89,8 @@ func newTempDir(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { os.RemoveAll(tmpdir) })
+
 	// Resolve /var/folders/.../T/... to /private/var/... in OSX
 	wd, err := os.Getwd()
 	if err != nil {

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -26,7 +26,6 @@ func samePathSlice(lhss, rhss []string) bool {
 func TestLocalRepositoryFromFullPath(t *testing.T) {
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
 	tmproot := newTempDir(t)
-	defer os.RemoveAll(tmproot)
 	_localRepositoryRoots = []string{tmproot}
 
 	testCases := []struct {
@@ -63,7 +62,6 @@ func TestLocalRepositoryFromFullPath(t *testing.T) {
 func TestNewLocalRepository(t *testing.T) {
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
 	tmproot := newTempDir(t)
-	defer os.RemoveAll(tmproot)
 	_localRepositoryRoots = []string{tmproot}
 
 	testCases := []struct {
@@ -167,10 +165,7 @@ func TestList_Symlink(t *testing.T) {
 		t.SkipNow()
 	}
 	root := newTempDir(t)
-	defer os.RemoveAll(root)
-
 	symDir := newTempDir(t)
-	defer os.RemoveAll(symDir)
 
 	origLocalRepositryRoots := _localRepositoryRoots
 	_localRepositoryRoots = []string{root}
@@ -203,10 +198,7 @@ func TestList_Symlink_In_Same_Directory(t *testing.T) {
 		t.SkipNow()
 	}
 	root := newTempDir(t)
-	defer os.RemoveAll(root)
-
 	symDir := newTempDir(t)
-	defer os.RemoveAll(symDir)
 
 	origLocalRepositryRoots := _localRepositoryRoots
 	_localRepositoryRoots = []string{root}
@@ -248,9 +240,7 @@ func TestFindVCSBackend(t *testing.T) {
 		setup: func(t *testing.T) (string, string, func()) {
 			dir := newTempDir(t)
 			os.MkdirAll(filepath.Join(dir, ".git"), 0755)
-			return dir, "", func() {
-				os.RemoveAll(dir)
-			}
+			return dir, "", func() {}
 		},
 		expect: GitBackend,
 	}, {
@@ -258,9 +248,7 @@ func TestFindVCSBackend(t *testing.T) {
 		setup: func(t *testing.T) (string, string, func()) {
 			dir := newTempDir(t)
 			os.MkdirAll(filepath.Join(dir, ".git", "svn"), 0755)
-			return dir, "", func() {
-				os.RemoveAll(dir)
-			}
+			return dir, "", func() {}
 		},
 		expect: GitBackend,
 	}, {
@@ -268,9 +256,7 @@ func TestFindVCSBackend(t *testing.T) {
 		setup: func(t *testing.T) (string, string, func()) {
 			dir := newTempDir(t)
 			os.MkdirAll(filepath.Join(dir, ".git"), 0755)
-			return dir, "git", func() {
-				os.RemoveAll(dir)
-			}
+			return dir, "git", func() {}
 		},
 		expect: GitBackend,
 	}, {
@@ -278,9 +264,7 @@ func TestFindVCSBackend(t *testing.T) {
 		setup: func(t *testing.T) (string, string, func()) {
 			dir := newTempDir(t)
 			os.MkdirAll(filepath.Join(dir, ".git"), 0755)
-			return dir, "mercurial", func() {
-				os.RemoveAll(dir)
-			}
+			return dir, "mercurial", func() {}
 		},
 		expect: nil,
 	}}

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -122,7 +122,6 @@ func TestNewLocalRepository(t *testing.T) {
 
 func TestLocalRepositoryRoots(t *testing.T) {
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
-	defer func(orig string) { os.Setenv(envGhqRoot, orig) }(os.Getenv(envGhqRoot))
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -147,7 +146,7 @@ func TestLocalRepositoryRoots(t *testing.T) {
 		t.Run(tc.root, func(t *testing.T) {
 			_localRepositoryRoots = nil
 			localRepoOnce = &sync.Once{}
-			os.Setenv(envGhqRoot, tc.root)
+			setEnv(t, envGhqRoot, tc.root)
 			got, err := localRepositoryRoots(true)
 			if err != nil {
 				t.Errorf("error should be nil, but: %s", err)
@@ -282,12 +281,11 @@ func TestFindVCSBackend(t *testing.T) {
 
 func TestLocalRepository_VCS(t *testing.T) {
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
-	defer func(orig string) { os.Setenv(envGhqRoot, orig) }(os.Getenv(envGhqRoot))
 
 	_localRepositoryRoots = nil
 	localRepoOnce = &sync.Once{}
 	tmpdir := newTempDir(t)
-	os.Setenv(envGhqRoot, tmpdir)
+	setEnv(t, envGhqRoot, tmpdir)
 
 	pkg := filepath.Join(tmpdir, "github.com", "motemen", "ghq")
 	subpkg := filepath.Join(pkg, "logger")
@@ -331,7 +329,7 @@ func TestLocalRepositoryRoots_URLMatchLocalRepositoryRoots(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
-	defer tmpEnv("HOME", "/home/tmp")()
+	setEnv(t, "HOME", "/home/tmp")
 	defer func(orig string) { _home = orig }(_home)
 
 	_home = ""

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -334,7 +334,7 @@ func TestLocalRepositoryRoots_URLMatchLocalRepositoryRoots(t *testing.T) {
 
 	_home = ""
 	homeOnce = &sync.Once{}
-	defer gitconfig.WithConfig(t, `
+	t.Cleanup(gitconfig.WithConfig(t, `
 [ghq]
   root = /hoge
 [ghq "https://github.com/hatena"]
@@ -342,7 +342,7 @@ func TestLocalRepositoryRoots_URLMatchLocalRepositoryRoots(t *testing.T) {
   root = /backups/hatena
 [ghq "https://github.com/natureglobal"]
   root = ~/proj/natureglobal
-`)()
+`))
 
 	want := []string{"/hoge", "/home/tmp/proj/hatena", "/backups/hatena", "/home/tmp/proj/natureglobal"}
 

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -233,46 +233,45 @@ func TestList_Symlink_In_Same_Directory(t *testing.T) {
 func TestFindVCSBackend(t *testing.T) {
 	testCases := []struct {
 		name   string
-		setup  func(t *testing.T) (string, string, func())
+		setup  func(t *testing.T) (string, string)
 		expect *VCSBackend
 	}{{
 		name: "git",
-		setup: func(t *testing.T) (string, string, func()) {
+		setup: func(t *testing.T) (string, string) {
 			dir := newTempDir(t)
 			os.MkdirAll(filepath.Join(dir, ".git"), 0755)
-			return dir, "", func() {}
+			return dir, ""
 		},
 		expect: GitBackend,
 	}, {
 		name: "git svn",
-		setup: func(t *testing.T) (string, string, func()) {
+		setup: func(t *testing.T) (string, string) {
 			dir := newTempDir(t)
 			os.MkdirAll(filepath.Join(dir, ".git", "svn"), 0755)
-			return dir, "", func() {}
+			return dir, ""
 		},
 		expect: GitBackend,
 	}, {
 		name: "git with matched vcs",
-		setup: func(t *testing.T) (string, string, func()) {
+		setup: func(t *testing.T) (string, string) {
 			dir := newTempDir(t)
 			os.MkdirAll(filepath.Join(dir, ".git"), 0755)
-			return dir, "git", func() {}
+			return dir, "git"
 		},
 		expect: GitBackend,
 	}, {
 		name: "git with not matched vcs",
-		setup: func(t *testing.T) (string, string, func()) {
+		setup: func(t *testing.T) (string, string) {
 			dir := newTempDir(t)
 			os.MkdirAll(filepath.Join(dir, ".git"), 0755)
-			return dir, "mercurial", func() {}
+			return dir, "mercurial"
 		},
 		expect: nil,
 	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fpath, vcs, teardown := tc.setup(t)
-			defer teardown()
+			fpath, vcs := tc.setup(t)
 			backend := findVCSBackend(fpath, vcs)
 			if backend != tc.expect {
 				t.Errorf("got: %v, expect: %v", backend, tc.expect)

--- a/url_test.go
+++ b/url_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -53,10 +52,7 @@ func TestNewURL(t *testing.T) {
 	}, {
 		name: "fill username",
 		setup: func(t *testing.T) {
-			key := "GITHUB_USER"
-			orig := os.Getenv(key)
-			os.Setenv(key, "ghq-test")
-			t.Cleanup(func() { os.Setenv(key, orig) })
+			setEnv(t, "GITHUB_USER", "ghq-test")
 		},
 		url:    "same-name-ghq",
 		expect: "https://github.com/ghq-test/same-name-ghq",
@@ -140,9 +136,9 @@ func TestNewURL_err(t *testing.T) {
 
 func TestFillUsernameToPath_err(t *testing.T) {
 	for _, envStr := range []string{"GITHUB_USER", "GITHUB_TOKEN", "USER", "USERNAME"} {
-		defer tmpEnv(envStr, "")()
+		setEnv(t, envStr, "")
 	}
-	defer tmpEnv("XDG_CONFIG_HOME", "/dummy/dummy")()
+	setEnv(t, "XDG_CONFIG_HOME", "/dummy/dummy")
 
 	usr, err := fillUsernameToPath("peco", false)
 	t.Log(usr)

--- a/url_test.go
+++ b/url_test.go
@@ -125,7 +125,7 @@ func TestNewURL_err(t *testing.T) {
 	if got := fmt.Sprint(err); !strings.Contains(got, wantSub) {
 		t.Errorf("newURL(%q, false, false) error = %q; want substring %q", invalidURL, got, wantSub)
 	}
-	defer gitconfig.WithConfig(t, `[[[`)()
+	t.Cleanup(gitconfig.WithConfig(t, `[[[`))
 
 	var exitError *exec.ExitError
 	_, err = newURL("peco", false, false)

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -28,7 +28,6 @@ Last Changed Date: 2019-08-16 15:16:45 +0900 (Fri, 16 Aug 2019)
 
 func TestVCSBackend(t *testing.T) {
 	tempDir := newTempDir(t)
-	defer os.RemoveAll(tempDir)
 	localDir := filepath.Join(tempDir, "repo")
 	_commands := []*exec.Cmd{}
 	lastCommand := func() *exec.Cmd { return _commands[len(_commands)-1] }
@@ -416,7 +415,6 @@ func TestVCSBackend(t *testing.T) {
 
 func TestCvsDummyBackend(t *testing.T) {
 	tempDir := newTempDir(t)
-	defer os.RemoveAll(tempDir)
 	localDir := filepath.Join(tempDir, "repo")
 
 	if err := cvsDummyBackend.Clone(&vcsGetOption{
@@ -443,7 +441,6 @@ func TestCvsDummyBackend(t *testing.T) {
 
 func TestBranchOptionIgnoredErrors(t *testing.T) {
 	tempDir := newTempDir(t)
-	defer os.RemoveAll(tempDir)
 	localDir := filepath.Join(tempDir, "repo")
 
 	if err := DarcsBackend.Clone(&vcsGetOption{


### PR DESCRIPTION
This PR suggests migrating test setup cleanup to use [`t.Cleanup`](https://pkg.go.dev/testing#T.Cleanup). This PR removes calling teardown returned by setup functions, also refactors environment variable setups. [An existing test fails to remove the temporally directory](https://github.com/x-motemen/ghq/blob/v1.3.0/local_repository_test.go#L306) but using `t.Cleanup` in test utility prevents a mistake like this. Note that `gitconfig.WithConfig` would be improved by  calling `t.Cleanup` inside it.