### PR TITLE
Support branch/tag via @ syntax

### DIFF
--- a/cmd_get_test.go
+++ b/cmd_get_test.go
@@ -157,6 +157,25 @@ func TestCommandGet(t *testing.T) {
 			}
 		},
 	}, {
+		name: "specific branch using @ syntax",
+		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+			localDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo")
+
+			expectBranch := "hello"
+			app.Run([]string{"", "get", "-shallow", "motemen/ghq-test-repo@" + expectBranch})
+
+			expect := "https://github.com/motemen/ghq-test-repo"
+			if cloneArgs.remote.String() != expect {
+				t.Errorf("got: %s, expect: %s", cloneArgs.remote, expect)
+			}
+			if filepath.ToSlash(cloneArgs.local) != filepath.ToSlash(localDir) {
+				t.Errorf("got: %s, expect: %s", filepath.ToSlash(cloneArgs.local), filepath.ToSlash(localDir))
+			}
+			if cloneArgs.branch != expectBranch {
+				t.Errorf("got: %q, expect: %q", cloneArgs.branch, expectBranch)
+			}
+		},
+	}, {
 		name: "with --no-recursive option",
 		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
 			app.Run([]string{"", "get", "--no-recursive", "motemen/ghq-test-repo"})

--- a/commands.go
+++ b/commands.go
@@ -98,7 +98,7 @@ func mkCommandsTemplate(genTemplate func(commandDoc) string) string {
 
 func init() {
 	argsTemplate := mkCommandsTemplate(func(doc commandDoc) string { return doc.Arguments })
-	parentTemplate := mkCommandsTemplate(func(doc commandDoc) string { return string(strings.TrimLeft(doc.Parent+" ", " ")) })
+	parentTemplate := mkCommandsTemplate(func(doc commandDoc) string { return strings.TrimLeft(doc.Parent+" ", " ") })
 
 	cli.CommandHelpTemplate = `NAME:
     {{.Name}} - {{.Usage}}

--- a/getter.go
+++ b/getter.go
@@ -21,10 +21,10 @@ func getRepoLock(localRepoRoot string) bool {
 
 type getter struct {
 	update, shallow, silent, ssh, recursive, bare bool
-	vcs, branch                                   string
+	vcs                                           string
 }
 
-func (g *getter) get(argURL string) error {
+func (g *getter) get(argURL, branch string) error {
 	u, err := newURL(argURL, g.ssh, false)
 	if err != nil {
 		return fmt.Errorf("Could not parse URL %q: %w", argURL, err)
@@ -35,13 +35,13 @@ func (g *getter) get(argURL string) error {
 		return err
 	}
 
-	return g.getRemoteRepository(remote)
+	return g.getRemoteRepository(remote, branch)
 }
 
 // getRemoteRepository clones or updates a remote repository remote.
 // If doUpdate is true, updates the locally cloned repository. Otherwise does nothing.
 // If isShallow is true, does shallow cloning. (no effect if already cloned or the VCS is Mercurial and git-svn)
-func (g *getter) getRemoteRepository(remote RemoteRepository) error {
+func (g *getter) getRemoteRepository(remote RemoteRepository, branch string) error {
 	remoteURL := remote.URL()
 	local, err := LocalRepositoryFromURL(remoteURL)
 	if err != nil {
@@ -95,7 +95,7 @@ func (g *getter) getRemoteRepository(remote RemoteRepository) error {
 				dir:       localRepoRoot,
 				shallow:   g.shallow,
 				silent:    g.silent,
-				branch:    g.branch,
+				branch:    branch,
 				recursive: g.recursive,
 				bare:      g.bare,
 			})

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -182,7 +182,7 @@ func TestList_Symlink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	paths := []string{}
+	var paths []string
 	walkAllLocalRepositories(func(repo *LocalRepository) {
 		paths = append(paths, repo.RelPath)
 	})
@@ -219,7 +219,7 @@ func TestList_Symlink_In_Same_Directory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	paths := []string{}
+	var paths []string
 	walkAllLocalRepositories(func(repo *LocalRepository) {
 		paths = append(paths, repo.RelPath)
 	})

--- a/remote_repository.go
+++ b/remote_repository.go
@@ -26,7 +26,7 @@ type GitHubRepository struct {
 	url *url.URL
 }
 
-// URL reutrns URL of the repository
+// URL returns URL of the repository
 func (repo *GitHubRepository) URL() *url.URL {
 	return repo.url
 }
@@ -58,12 +58,12 @@ type GitHubGistRepository struct {
 	url *url.URL
 }
 
-// URL returns URL of the GistRepositroy
+// URL returns URL of the GistRepository
 func (repo *GitHubGistRepository) URL() *url.URL {
 	return repo.url
 }
 
-// IsValid determine if the gist rpository is valid or not
+// IsValid determine if the gist repository is valid or not
 func (repo *GitHubGistRepository) IsValid() bool {
 	return true
 }

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -29,7 +29,7 @@ Last Changed Date: 2019-08-16 15:16:45 +0900 (Fri, 16 Aug 2019)
 func TestVCSBackend(t *testing.T) {
 	tempDir := newTempDir(t)
 	localDir := filepath.Join(tempDir, "repo")
-	_commands := []*exec.Cmd{}
+	var _commands []*exec.Cmd
 	lastCommand := func() *exec.Cmd { return _commands[len(_commands)-1] }
 	defer func(orig func(cmd *exec.Cmd) error) {
 		cmdutil.CommandRunner = orig


### PR DESCRIPTION
Thanks for the neat tool.
I thought it would be nice if @ syntax was supported for branch/tag just like `go get` does. I did eventually find the `--branch` option but @ seems appropriate given this tool was originally inspired by the Go tooling.

This also has the advantage of allowing you to choose different branches when getting multiple repos at once, eg:

```shell
ghq get -P x-motemen/ghq@gotesplit men/gore@main NathanBaulch/rainbow-roads@v0.3.0
```

I don't know about the other supported VCS providers but you can't directly clone a specific commit SHA in Git, so this `go get` scenario wouldn't be supported.

This implementation is pretty naive and will break if the repository URL contains an @ symbol for some reason. If this feature sounds useful then maybe we can come up with something more robust, perhaps by [validating the branch/tag name](https://stackoverflow.com/questions/3651860).

Cheers.