### PR TITLE
adjustment

### DIFF
--- a/cmd_root.go
+++ b/cmd_root.go
@@ -7,24 +7,20 @@ import (
 )
 
 func doRoot(c *cli.Context) error {
-	var (
-		w   = c.App.Writer
-		all = c.Bool("all")
-	)
-	if all {
-		roots, err := localRepositoryRoots(true)
-		if err != nil {
-			return err
-		}
-		for _, root := range roots {
-			fmt.Fprintln(w, root)
-		}
-		return nil
-	}
-	root, err := primaryLocalRepositoryRoot()
+	roots, err := localRepositoryRoots(true)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(w, root)
+	if !c.Bool("all") {
+		roots = roots[:1] // only the first root is needed
+	}
+
+	for _, root := range roots {
+		_, err := fmt.Fprintln(c.App.Writer, root)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/local_repository.go
+++ b/local_repository.go
@@ -117,10 +117,10 @@ func LocalRepositoryFromURL(remoteURL *url.URL) (*LocalRepository, error) {
 
 func getRoot(u string) (string, error) {
 	prim := os.Getenv(envGhqRoot)
-	var err error
 	if prim != "" {
 		return prim, nil
 	}
+	var err error
 	if !codecommitLikeURLPattern.MatchString(u) {
 		prim, err = gitconfig.Do("--path", "--get-urlmatch", "ghq.root", u)
 		if err != nil && !gitconfig.IsNotFound(err) {


### PR DESCRIPTION
I want to simplify `doRoot()` by unifying the two cases.

Btw, the `all` arguments for `doRoot()` and `localRespositoryRoots()` have different meanings. Maybe it's better to use another name for the latter?