### PR TITLE
Support pijul

### DIFF
--- a/cmd_create_test.go
+++ b/cmd_create_test.go
@@ -73,6 +73,11 @@ func TestDoCreate(t *testing.T) {
 		want:    []string{"darcs", "init"},
 		wantDir: filepath.Join(tmpd, "github.com/motemen/ghq-darcs"),
 	}, {
+		name:    "Pijul",
+		input:   []string{"create", "--vcs=pijul", "motemen/ghq-pijul"},
+		want:    []string{"pijul", "init"},
+		wantDir: filepath.Join(tmpd, "github.com/motemen/ghq-pijul"),
+	}, {
 		name:    "Bazzar",
 		input:   []string{"create", "--vcs=bzr", "motemen/ghq-bzr"},
 		want:    []string{"bzr", "init"},

--- a/local_repository.go
+++ b/local_repository.go
@@ -208,6 +208,7 @@ var vcsContentsMap = map[string]*VCSBackend{
 	".hg":            MercurialBackend,
 	".svn":           SubversionBackend,
 	"_darcs":         DarcsBackend,
+	".pijul":         PijulBackend,
 	".bzr":           BazaarBackend,
 	".fslckout":      FossilBackend, // file
 	"_FOSSIL_":       FossilBackend, // file
@@ -219,6 +220,7 @@ var vcsContents = [...]string{
 	".hg",
 	".svn",
 	"_darcs",
+	".pijul",
 	".bzr",
 	".fslckout",
 	"._FOSSIL_",

--- a/logger/log.go
+++ b/logger/log.go
@@ -14,6 +14,7 @@ var logger = colorine.NewLogger(
 		"hg":       colorine.Verbose,
 		"svn":      colorine.Verbose,
 		"darcs":    colorine.Verbose,
+		"pijul":    colorine.Verbose,
 		"bzr":      colorine.Verbose,
 		"fossil":   colorine.Verbose,
 		"skip":     colorine.Verbose,

--- a/remote_repository.go
+++ b/remote_repository.go
@@ -93,6 +93,26 @@ func (repo *DarksHubRepository) VCS() (*VCSBackend, *url.URL, error) {
 	return DarcsBackend, repo.URL(), nil
 }
 
+// NestPijulRepository represents the Nest repository
+type NestPijulRepository struct {
+	url *url.URL
+}
+
+// URL returns URL of the Nest repository
+func (repo *NestPijulRepository) URL() *url.URL {
+	return repo.url
+}
+
+// IsValid determine if the Nest repository is valid or not
+func (repo *NestPijulRepository) IsValid() bool {
+	return strings.Count(repo.url.Path, "/") == 2
+}
+
+// VCS returns VCSBackend of the Nest repository
+func (repo *NestPijulRepository) VCS() (*VCSBackend, *url.URL, error) {
+	return PijulBackend, repo.URL(), nil
+}
+
 // A CodeCommitRepository represents a CodeCommit repository. Implements RemoteRepository.
 type CodeCommitRepository struct {
 	url *url.URL
@@ -197,6 +217,8 @@ func NewRemoteRepository(u *url.URL) (RemoteRepository, error) {
 			return &GitHubGistRepository{u}
 		case "hub.darcs.net":
 			return &DarksHubRepository{u}
+		case "nest.pijul.com":
+			return &NestPijulRepository{u}
 		default:
 			return &OtherRepository{u}
 		}

--- a/remote_repository_test.go
+++ b/remote_repository_test.go
@@ -36,6 +36,10 @@ func TestNewRemoteRepository(t *testing.T) {
 		valid:      true,
 		vcsBackend: DarcsBackend,
 	}, {
+		url:        "http://nest.pijul.com/foo/bar",
+		valid:      true,
+		vcsBackend: PijulBackend,
+	}, {
 		url:        "svn+ssh://example.com/proj/repo",
 		valid:      true,
 		vcsBackend: SubversionBackend,

--- a/vcs.go
+++ b/vcs.go
@@ -300,10 +300,6 @@ var DarcsBackend = &VCSBackend{
 // PijulBackend is the VCSBackend for pijul
 var PijulBackend = &VCSBackend{
 	Clone: func(vg *vcsGetOption) error {
-		if vg.branch != "" {
-			return errors.New("pijul does not support branch")
-		}
-
 		dir, _ := filepath.Split(vg.dir)
 		err := os.MkdirAll(dir, 0755)
 		if err != nil {
@@ -311,6 +307,9 @@ var PijulBackend = &VCSBackend{
 		}
 
 		args := []string{"clone"}
+		if vg.branch != "" {
+			args = append(args, "--channel", vg.branch)
+		}
 		args = append(args, vg.url.String(), vg.dir)
 
 		return run(vg.silent)("pijul", args...)

--- a/vcs.go
+++ b/vcs.go
@@ -297,6 +297,33 @@ var DarcsBackend = &VCSBackend{
 	Contents: []string{"_darcs"},
 }
 
+// PijulBackend is the VCSBackend for pijul
+var PijulBackend = &VCSBackend{
+	Clone: func(vg *vcsGetOption) error {
+		if vg.branch != "" {
+			return errors.New("pijul does not support branch")
+		}
+
+		dir, _ := filepath.Split(vg.dir)
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return err
+		}
+
+		args := []string{"clone"}
+		args = append(args, vg.url.String(), vg.dir)
+
+		return run(vg.silent)("pijul", args...)
+	},
+	Update: func(vg *vcsGetOption) error {
+		return runInDir(vg.silent)(vg.dir, "pijul", "pull")
+	},
+	Init: func(dir string) error {
+		return cmdutil.RunInDir(dir, "pijul", "init")
+	},
+	Contents: []string{".pijul"},
+}
+
 var cvsDummyBackend = &VCSBackend{
 	Clone: func(vg *vcsGetOption) error {
 		return errors.New("CVS clone is not supported")
@@ -370,6 +397,7 @@ var vcsRegistry = map[string]*VCSBackend{
 	"hg":         MercurialBackend,
 	"mercurial":  MercurialBackend,
 	"darcs":      DarcsBackend,
+	"pijul":      PijulBackend,
 	"fossil":     FossilBackend,
 	"bzr":        BazaarBackend,
 	"bazaar":     BazaarBackend,

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -349,6 +349,24 @@ func TestVCSBackend(t *testing.T) {
 		expect: []string{"darcs", "pull"},
 		dir:    localDir,
 	}, {
+		name: "[pijul] clone",
+		f: func() error {
+			return PijulBackend.Clone(&vcsGetOption{
+				url: remoteDummyURL,
+				dir: localDir,
+			})
+		},
+		expect: []string{"pijul", "clone", remoteDummyURL.String(), localDir},
+	}, {
+		name: "[pijul] update",
+		f: func() error {
+			return PijulBackend.Update(&vcsGetOption{
+				dir: localDir,
+			})
+		},
+		expect: []string{"pijul", "pull"},
+		dir:    localDir,
+	}, {
 		name: "[bzr] clone",
 		f: func() error {
 			return BazaarBackend.Clone(&vcsGetOption{


### PR DESCRIPTION
Add support for pijul (https://pijul.org/) and its repository hosting service the Nest (https://nest.pijul.com/)

```
% ghq get -u https://nest.pijul.com/pijul/nest
     clone https://nest.pijul.com/pijul/nest -> /Users/yoichi/ghq/nest.pijul.com/pijul/nest
     pijul clone https://nest.pijul.com/pijul/nest /Users/yoichi/ghq/nest.pijul.com/pijul/nest
Repository created at /Users/yoichi/ghq/nest.pijul.com/pijul/nest
Downloading changes [==================================================] 1/1
           Applying [==================================================] 1/1
 Completing changes [==================================================] 0/0
% ghq get -u https://nest.pijul.com/pijul/nest
    update /Users/yoichi/ghq/nest.pijul.com/pijul/nest
     pijul pull
Downloading changes [==================================================] 0/0
Nothing to pull
```