### PR TITLE
Added mise-en-place installation and usage instructions.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -169,6 +169,13 @@ asdf plugin add ghq
 asdf install ghq latest
 ----
 
+=== https://github.com/jdx/mise[mise-en-place]
+
+----
+mise install ghq
+mise use ghq
+----
+
 === build
 
 ----


### PR DESCRIPTION
ghq is now also available as a mise-en-place plugin.
I have added instructions for using mise-en-place to install ghq in the README.
This is similar to the content in PR #305.