### PR TITLE
Feat: add alias for `ghq get`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,8 @@ ghq root [--all]
 
 get::
     Clone a remote repository under ghq root directory (see
-    <<directory-structures,DIRECTORY STRUCTURES>> below). If the repository is
+    <<directory-structures,DIRECTORY STRUCTURES>> below). `ghq clone` is an alias for this command.
+    If the repository is
     already cloned to local, nothing will happen unless '-u' ('--update')
     flag is supplied, in which case the local repository is updated ('git pull --ff-only' eg.).
     When you use '-p' option, the repository is cloned via SSH protocol. +

--- a/commands.go
+++ b/commands.go
@@ -16,8 +16,9 @@ var commands = []*cli.Command{
 }
 
 var commandGet = &cli.Command{
-	Name:  "get",
-	Usage: "Clone/sync with a remote repository",
+	Name:    "get",
+	Aliases: []string{"clone"},
+	Usage:   "Clone/sync with a remote repository",
 	Description: `
     Clone a repository under ghq root directory. If the repository is
     already cloned to local, nothing will happen unless '-u' ('--update')


### PR DESCRIPTION
close #374 

## Feature Description

- add `ghq clone` command
    - `ghq clone` is an alias for `ghq get`

### Example

```bash
$ pwd
path/to/ghq (forked)

$ make build && ./ghq clone https://github.com/x-motemen/ghq
     clone https://github.com/x-motemen/ghq -> /Users/junya/src/github.com/x-motemen/ghq
       git clone --recursive https://github.com/x-motemen/ghq /Users/junya/src/github.com/x-motemen/ghq
Cloning into '/Users/junya/src/github.com/x-motemen/ghq'...
remote: Enumerating objects: 3325, done.
remote: Counting objects: 100% (441/441), done.
remote: Compressing objects: 100% (220/220), done.
remote: Total 3325 (delta 243), reused 368 (delta 213), pack-reused 2884
Receiving objects: 100% (3325/3325), 820.82 KiB | 4.80 MiB/s, done.
Resolving deltas: 100% (2024/2024), done.
```
