### PR TITLE
feat: enable relative path ssh URL

### DIFF
--- a/url.go
+++ b/url.go
@@ -112,7 +112,7 @@ func newURL(ref string, ssh, forceMe bool) (*url.URL, error) {
 			user := matched[1]
 			host := matched[2]
 			path := matched[3]
-			// When two conditons below are satisfied:
+			// When two conditions below are satisfied:
 			// 1. the path is a relative path, which not beginning with a slash, like `path/to/repo`.
 			// 2. the host is not github.com, which doesn't support relative paths.
 			// then we convert the given SCP style URL to a normal style and relative path URL using tilde, like `ssh://user@repo.example.com/~/path/to/repo`.

--- a/url.go
+++ b/url.go
@@ -112,12 +112,16 @@ func newURL(ref string, ssh, forceMe bool) (*url.URL, error) {
 			user := matched[1]
 			host := matched[2]
 			path := matched[3]
-			// If the path is a relative path not beginning with a slash like
-			// `path/to/repo`, we might convert to like
-			// `ssh://user@repo.example.com/~/path/to/repo` using tilde, but
-			// since GitHub doesn't support it, we treat relative and absolute
-			// paths the same way.
-			ref = fmt.Sprintf("ssh://%s%s/%s", user, host, strings.TrimPrefix(path, "/"))
+			// When two conditons below are satisfied:
+			// 1. the path is a relative path, which not beginning with a slash, like `path/to/repo`.
+			// 2. the host is not github.com, which doesn't support relative paths.
+			// then we convert the given SCP style URL to a normal style and relative path URL using tilde, like `ssh://user@repo.example.com/~/path/to/repo`.
+			if strings.HasPrefix(path, "/") {
+				path = strings.TrimPrefix(path, "/")
+			} else if host != "github.com" {
+				path = "~/" + path
+			}
+			ref = fmt.Sprintf("ssh://%s%s/%s", user, host, path)
 		} else {
 			// If ref is like "github.com/motemen/ghq" convert to "https://github.com/motemen/ghq"
 			paths := strings.Split(ref, "/")

--- a/url_test.go
+++ b/url_test.go
@@ -20,20 +20,35 @@ func TestNewURL(t *testing.T) {
 		expect: "https://github.com/motemen/pusheen-explorer",
 		host:   "github.com",
 	}, {
-		name:   "scp", // Convert SCP-like URL to SSH URL
+		name:   "scp to github", // Convert SCP-like URL to SSH URL
 		url:    "git@github.com:motemen/pusheen-explorer.git",
 		expect: "ssh://git@github.com/motemen/pusheen-explorer.git",
 		host:   "github.com",
 	}, {
-		name:   "scp with root",
+		name:   "scp with root to github",
 		url:    "git@github.com:/motemen/pusheen-explorer.git",
 		expect: "ssh://git@github.com/motemen/pusheen-explorer.git",
 		host:   "github.com",
 	}, {
-		name:   "scp without user",
+		name:   "scp without user to github",
 		url:    "github.com:motemen/pusheen-explorer.git",
 		expect: "ssh://github.com/motemen/pusheen-explorer.git",
 		host:   "github.com",
+	}, {
+		name:   "scp to others",
+		url:    "git@example.com:repo/www.git",
+		expect: "ssh://git@example.com/~/repo/www.git",
+		host:   "example.com",
+	}, {
+		name:   "scp with root to others",
+		url:    "git@example.com:/repo/www.git",
+		expect: "ssh://git@example.com/repo/www.git",
+		host:   "example.com",
+	}, {
+		name:   "scp without user to others",
+		url:    "example.com:repo/www.git",
+		expect: "ssh://example.com/~/repo/www.git",
+		host:   "example.com",
 	}, {
 		name:   "different name repository",
 		url:    "motemen/ghq",


### PR DESCRIPTION
Enable relative path in SCP style URL if the host is not `github.com`. This allows to specify the ssh repository by shorter URL, like http ones.