### PR TITLE
chore: Update "go build" lines

### DIFF
--- a/helpers_unix.go
+++ b/helpers_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package main
 

--- a/helpers_windows.go
+++ b/helpers_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package main
 


### PR DESCRIPTION
## Change List

- Update "go build" lines in helpers_*.go

## Note

FYI: [Go 1.17 Release Notes](https://go.dev/doc/go1.17#go:build)

> //go:build lines
> 
> The go command now understands //go:build lines and prefers them over // +build lines. The new syntax uses boolean expressions, just like Go, and should be less error-prone. As of this release, the new syntax is fully supported, and all Go files should be updated to have both forms with the same meaning. To aid in migration, gofmt now automatically synchronizes the two forms. For more details on the syntax and migration plan, see https://golang.org/design/draft-gobuild.