### PR TITLE
improve --silent flag in get command

### DIFF
--- a/cmd_get.go
+++ b/cmd_get.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,13 +24,14 @@ func doGet(c *cli.Context) error {
 		args     = c.Args().Slice()
 		andLook  = c.Bool("look")
 		parallel = c.Bool("parallel")
+		silent   = c.Bool("silent")
 	)
 	g := &getter{
 		update:    c.Bool("update"),
 		shallow:   c.Bool("shallow"),
 		ssh:       c.Bool("p"),
 		vcs:       c.String("vcs"),
-		silent:    c.Bool("silent"),
+		silent:    silent,
 		branch:    c.String("branch"),
 		recursive: !c.Bool("no-recursive"),
 		bare:      c.Bool("bare"),
@@ -37,6 +39,9 @@ func doGet(c *cli.Context) error {
 	if parallel {
 		// force silent in parallel import
 		g.silent = true
+	}
+	if silent {
+		logger.SetOutput(io.Discard)
 	}
 
 	var (

--- a/cmd_get_test.go
+++ b/cmd_get_test.go
@@ -221,6 +221,33 @@ func TestCommandGet(t *testing.T) {
 				t.Errorf("cloneArgs.bare should be true")
 			}
 		},
+	}, {
+		name: "silent mode",
+		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+			localDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo")
+
+			out, _, err := captureWithInput([]string{}, func() {
+				app.Run([]string{"", "get", "--silent", "motemen/ghq-test-repo"})
+			})
+			if err != nil {
+				t.Errorf("error should be nil, but: %s", err)
+			}
+
+			expect := "https://github.com/motemen/ghq-test-repo"
+			if cloneArgs.remote.String() != expect {
+				t.Errorf("got: %s, expect: %s", cloneArgs.remote, expect)
+			}
+			if filepath.ToSlash(cloneArgs.local) != filepath.ToSlash(localDir) {
+				t.Errorf("got: %s, expect: %s", filepath.ToSlash(cloneArgs.local), filepath.ToSlash(localDir))
+			}
+
+			if !cloneArgs.silent {
+				t.Errorf("cloneArgs.silent should be true")
+			}
+			if out != "" {
+				t.Errorf("silent mode should not output any logs, but got: %s", out)
+			}
+		},
 	}}
 
 	for _, tc := range testCases {

--- a/commands_test.go
+++ b/commands_test.go
@@ -14,6 +14,7 @@ type _cloneArgs struct {
 	branch    string
 	recursive bool
 	bare      bool
+	silent    bool
 }
 
 type _updateArgs struct {
@@ -39,6 +40,7 @@ func withFakeGitBackend(t *testing.T, block func(*testing.T, string, *_cloneArgs
 				branch:    vg.branch,
 				recursive: vg.recursive,
 				bare:      vg.bare,
+				silent:    vg.silent,
 			}
 			return nil
 		},


### PR DESCRIPTION
fixed #413 

## What
- Changed that `--silent ` flag in get command also suppress log output.

## Why
- I hope `—silent` flag suppress all the outputs