### PR TITLE
Print repository path after get

### DIFF
--- a/cmd_get.go
+++ b/cmd_get.go
@@ -77,6 +77,12 @@ func doGet(c *cli.Context) error {
 			if getInfo, err = g.get(target); err != nil {
 				return fmt.Errorf("failed to get %q: %w", target, err)
 			}
+			fd := os.Stdout.Fd()
+			if !isatty.IsTerminal(fd) && !isatty.IsCygwinTerminal(fd) {
+				if getInfo.localRepository != nil {
+					fmt.Println(getInfo.localRepository.FullPath)
+				}
+			}
 		}
 	}
 	if err = scr.Err(); err != nil {


### PR DESCRIPTION
fixed #352

## What
- This ensures that the repository path is printed only when the output is not directed to an interactive terminal, such as when piping or redirecting to a file.

## Why
- The intended behavior is as follows:

```shell-session
$ cd $(get get --silent github.com/x-motemen/ghq)
```