### PR TITLE
Enable customizing the host folder name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,11 +93,19 @@ ghq.<url>.root::
     you can specify a repository-specific root directory instead of the common ghq root directory. +
     The URL is matched against '<url>' using 'git config --get-urlmatch'.
 
+ghq<url>.hostFolderName::
+    By default, ghq uses the hostname from the repository URL as the directory name
+    (e.g., "github.com" for GitHub repositories). With this option, you can specify
+    a custom folder name to use instead of the hostname for all repositories. +
+    For example, setting this to "gh" will cause GitHub repositories to be stored
+    under "gh/" instead of "github.com/".
+
 
 === Example configuration (.gitconfig):
 
 ....
 [ghq "https://git.example.com/repos/"]
+hostFolderName = example
 vcs = git
 root = ~/myproj
 ....

--- a/cmd_get_test.go
+++ b/cmd_get_test.go
@@ -194,7 +194,7 @@ func TestCommandGet(t *testing.T) {
 			tmpd := newTempDir(t)
 			t.Cleanup(gitconfig.WithConfig(t, fmt.Sprintf(`
 [ghq "https://github.com/motemen"]
-	 root = "%s"
+root = "%s"
 `, filepath.ToSlash(tmpd))))
 			app.Run([]string{"", "get", "motemen/ghq-test-repo"})
 

--- a/cmd_get_test.go
+++ b/cmd_get_test.go
@@ -194,11 +194,25 @@ func TestCommandGet(t *testing.T) {
 			tmpd := newTempDir(t)
 			t.Cleanup(gitconfig.WithConfig(t, fmt.Sprintf(`
 [ghq "https://github.com/motemen"]
-  root = "%s"
+	 root = "%s"
 `, filepath.ToSlash(tmpd))))
 			app.Run([]string{"", "get", "motemen/ghq-test-repo"})
 
 			localDir := filepath.Join(tmpd, "github.com", "motemen", "ghq-test-repo")
+			if filepath.ToSlash(cloneArgs.local) != filepath.ToSlash(localDir) {
+				t.Errorf("got: %s, expect: %s", filepath.ToSlash(cloneArgs.local), filepath.ToSlash(localDir))
+			}
+		},
+	}, {
+		name: "ghq<url>.hostFolderName",
+		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+			t.Cleanup(gitconfig.WithConfig(t, `
+[ghq "https://github.com"]
+	 hostFolderName = gh
+`))
+			app.Run([]string{"", "get", "motemen/ghq-test-repo"})
+
+			localDir := filepath.Join(tmpRoot, "gh", "motemen", "ghq-test-repo")
 			if filepath.ToSlash(cloneArgs.local) != filepath.ToSlash(localDir) {
 				t.Errorf("got: %s, expect: %s", filepath.ToSlash(cloneArgs.local), filepath.ToSlash(localDir))
 			}

--- a/getter.go
+++ b/getter.go
@@ -148,15 +148,12 @@ func (g *getter) getRemoteRepository(remote RemoteRepository, branch string) (ge
 
 func detectLocalRepoRoot(remotePath, repoPath string) string {
 	remotePath = strings.TrimSuffix(strings.TrimSuffix(remotePath, "/"), ".git")
-	logger.Log("remotePath", fmt.Sprintf("%s", remotePath))
 	repoPath = strings.TrimSuffix(strings.TrimSuffix(repoPath, "/"), ".git")
-	logger.Log("repoPath", fmt.Sprintf("%s", repoPath))
 	pathParts := strings.Split(repoPath, "/")
 	pathParts = pathParts[1:]
 	for i := 0; i < len(pathParts); i++ {
 		subPath := "/" + path.Join(pathParts[i:]...)
 		if subIdx := strings.Index(remotePath, subPath); subIdx >= 0 {
-			logger.Log("Returning from detectLocalRepoRoot", fmt.Sprintf("subidx %d, subPath %s", subIdx, subPath))
 			return remotePath[0:subIdx] + subPath
 		}
 	}

--- a/getter.go
+++ b/getter.go
@@ -92,8 +92,12 @@ func (g *getter) getRemoteRepository(remote RemoteRepository, branch string) (ge
 				return getInfo{}, err
 			}
 		}
+		hostFolderName, err := getHostFolderName(remoteURL)
+		if err != nil {
+			return getInfo{}, err
+		}
 		if l := detectLocalRepoRoot(remoteURL.Path, repoURL.Path); l != "" {
-			localRepoRoot = filepath.Join(local.RootPath, remoteURL.Hostname(), l)
+			localRepoRoot = filepath.Join(local.RootPath, hostFolderName, l)
 		}
 
 		if g.bare {
@@ -144,12 +148,15 @@ func (g *getter) getRemoteRepository(remote RemoteRepository, branch string) (ge
 
 func detectLocalRepoRoot(remotePath, repoPath string) string {
 	remotePath = strings.TrimSuffix(strings.TrimSuffix(remotePath, "/"), ".git")
+	logger.Log("remotePath", fmt.Sprintf("%s", remotePath))
 	repoPath = strings.TrimSuffix(strings.TrimSuffix(repoPath, "/"), ".git")
+	logger.Log("repoPath", fmt.Sprintf("%s", repoPath))
 	pathParts := strings.Split(repoPath, "/")
 	pathParts = pathParts[1:]
 	for i := 0; i < len(pathParts); i++ {
 		subPath := "/" + path.Join(pathParts[i:]...)
 		if subIdx := strings.Index(remotePath, subPath); subIdx >= 0 {
+			logger.Log("Returning from detectLocalRepoRoot", fmt.Sprintf("subidx %d, subPath %s", subIdx, subPath))
 			return remotePath[0:subIdx] + subPath
 		}
 	}

--- a/local_repository.go
+++ b/local_repository.go
@@ -73,8 +73,12 @@ func LocalRepositoryFromFullPath(fullPath string, backend *VCSBackend) (*LocalRe
 
 // LocalRepositoryFromURL resolve LocalRepository from URL
 func LocalRepositoryFromURL(remoteURL *url.URL, bare bool) (*LocalRepository, error) {
+	hostFolderName, err := getHostFolderName(remoteURL)
+	if err != nil {
+		return nil, err
+	}
 	pathParts := append(
-		[]string{remoteURL.Hostname()}, strings.Split(remoteURL.Path, "/")...,
+		[]string{hostFolderName}, strings.Split(remoteURL.Path, "/")...,
 	)
 	relPath := strings.TrimSuffix(filepath.Join(pathParts...), ".git")
 	pathParts[len(pathParts)-1] = strings.TrimSuffix(pathParts[len(pathParts)-1], ".git")
@@ -139,6 +143,30 @@ func getRoot(u string) (string, error) {
 		}
 	}
 	return prim, nil
+}
+
+// getHostFolderName returns the configured host folder name for the given URL,
+// or the hostname if no specific configuration is found
+// getHostFolderName returns the configured host folder name for the given URL,
+// or the hostname if no specific configuration is found
+func getHostFolderName(remoteURL *url.URL) (string, error) {
+	// Try to get ghq.hostFolderName config
+	hostFolderName, err := gitconfig.Do("--path", "--get-urlmatch", "ghq.hostFolderName", remoteURL.String())
+	if err != nil {
+		if gitconfig.IsNotFound(err) {
+			// No config found, use hostname
+			return remoteURL.Hostname(), nil
+		}
+		return "", err
+	}
+	
+	// If config exists and is not empty, use it
+	if strings.TrimSpace(hostFolderName) != "" {
+		return strings.TrimSpace(hostFolderName), nil
+	}
+	
+	// If config exists but is empty, use hostname
+	return remoteURL.Hostname(), nil
 }
 
 // Subpaths returns lists of tail parts of relative path from the root directory (shortest first)


### PR DESCRIPTION
Allows for customization using `.gitconfig` of the folder under `root` that is used to checkout repositories (instead of the git remote hostname).

So eg if I had
```
[ghq]
root = ~/repos

[ghq "https://github.com"]
hostFolderName = "gh"
```

when I run `ghq get https://github.com/x-motemen/ghq.git`, it would be cloned to `~/repos/gh/x-motemen/ghq`