### PR TITLE
docs: add description for `ghq.user` and `ghq. completeUser`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -85,6 +85,13 @@ ghq.user::
     By default, the owner used is the value of the environment variable `USER` (or `USERNAME` on Windows).
     Setting this option allows you to explicitly specify the owner.
 
+ghq.completeUser::
+    Rather than always using your own username for owner completion,
+    you may want to complete the owner with the same name as the repository.
+    For example, fetch `ruby` as `github.com/ruby/ruby`,
+    `vim` as `github.com/vim/vim`, and `peco` as `github.com/peco/peco`.
+    If you prefer this behavior, set this option to `false` to switch the owner completion method.
+
 ghq.<url>.vcs::
     ghq tries to detect the remote repository's VCS backend for non-"github.com"
     repositories.  With this option you can explicitly specify the VCS for the


### PR DESCRIPTION
Thank you for the wonderful OSS project! I love it so much that I can't develop comfortably without it.

This PR adds the following settings:
- ghq.user
- ghq.completeUser

I referred to the following documentation for the explanation of these settings:

[ghq-handbook/ja/04-command-get.md at master · Songmu/ghq-handbook](https://github.com/Songmu/ghq-handbook/blob/master/ja/04-command-get.md#ghq-get-project%E3%81%A7%E3%81%AEowner%E6%A4%9C%E5%87%BA)