### PR TITLE
feat: support ghq.look configuration in gitconfig

### DIFF
--- a/cmd_get.go
+++ b/cmd_get.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Songmu/gitconfig"
 	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 	"github.com/x-motemen/ghq/cmdutil"
@@ -26,6 +27,15 @@ func doGet(c *cli.Context) error {
 		parallel = c.Bool("parallel")
 		silent   = c.Bool("silent")
 	)
+	if !andLook {
+		v, err := gitconfig.Bool("ghq.look")
+		if err != nil && !gitconfig.IsNotFound(err) {
+			return err
+		}
+		if err == nil {
+			andLook = v
+		}
+	}
 	g := &getter{
 		update:    c.Bool("update"),
 		shallow:   c.Bool("shallow"),


### PR DESCRIPTION
# Support ghq.look configuration in gitconfig

## Summary

Related to #419

Allow users to set `ghq.look = true` in gitconfig to use `--look` by
default, without specifying the flag on every invocation.

```ini
[ghq]
    look = true
```

## Changes

- Read `ghq.look` from gitconfig as a fallback when `--look` flag is not given
- Add `TestLookFromGitConfig` to verify the behavior
