### PR TITLE
feat(get): add `ghq.defaultHost` config to resolve the default host.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -98,6 +98,11 @@ ghq.completeUser::
     `vim` as `github.com/vim/vim`, and `peco` as `github.com/peco/peco`.
     If you prefer this behavior, set this option to `false` to switch the owner completion method.
 
+ghq.defaultHost::
+    The default host used when the repository specification omits the host.
+    For example, `ghq get owner/project` normally resolves to `github.com/owner/project`.
+    If this option is set, the specified host will be used instead.
+
 ghq.<url>.vcs::
     ghq tries to detect the remote repository's VCS backend for non-"github.com"
     repositories.  With this option you can explicitly specify the VCS for the

--- a/url.go
+++ b/url.go
@@ -139,7 +139,12 @@ func newURL(ref string, ssh, forceMe bool) (*url.URL, error) {
 			}
 		}
 		u.Scheme = "https"
-		u.Host = "github.com"
+		host, err := gitconfig.Get("ghq.defaultHost")
+		if (err != nil && !gitconfig.IsNotFound(err)) || host != "" {
+			u.Host = host
+		} else {
+			u.Host = "github.com"
+		}
 		if u.Path[0] != '/' {
 			u.Path = "/" + u.Path
 		}

--- a/url_test.go
+++ b/url_test.go
@@ -66,6 +66,15 @@ completeUser = false`))
 		url:    "peco",
 		expect: "https://github.com/peco/peco",
 		host:   "github.com",
+	}, {
+		name: "configured default host",
+		setup: func(t *testing.T) {
+			t.Cleanup(gitconfig.WithConfig(t, `[ghq]
+defaultHost = gitlab.com`))
+		},
+		url:    "gnuwget/wget2",
+		expect: "https://gitlab.com/gnuwget/wget2",
+		host:   "gitlab.com",
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Related to #470 

This PR introduces a new git config option:

```gitconfig
[ghq]
    defaultHost = gitlab.example.com
```

With this configuration:

```sh
ghq get foo/bar
```

will resolve to: `https://gitlab.example.com/foo/bar`

If the `ghq.defaultHost` is not set, the behavior would remain unchanged (fallback to `https://github.com/foo/bar`).