### PR TITLE
fix(test): exercise `ghq rm` in command tests

### DIFF
--- a/cmd_rm_test.go
+++ b/cmd_rm_test.go
@@ -146,7 +146,9 @@ func TestRmDryRunCommand(t *testing.T) {
 			name:  "simple",
 			input: []string{"rm", "--dry-run", "motemen/ghqq"},
 			setup: func(t *testing.T) {
-				os.MkdirAll(filepath.Join(tmpd, "github.com", "motemen", "ghqq"), 0755)
+				if err := os.MkdirAll(filepath.Join(tmpd, "github.com", "motemen", "ghqq", ".git"), 0755); err != nil {
+					t.Fatal(err)
+				}
 			},
 			expectErr: false,
 		},
@@ -166,9 +168,9 @@ func TestRmDryRunCommand(t *testing.T) {
 		},
 		{
 			name:  "permission denied",
-			input: []string{"rm", "--dry-run", "motemen/ghqq"},
+			input: []string{"rm", "--dry-run", "motemen/ghq-notpermitted"},
 			setup: func(t *testing.T) {
-				f := filepath.Join(tmpd, "github.com", "motemen", "ghqq")
+				f := filepath.Join(tmpd, "github.com", "motemen", "ghq-notpermitted")
 				os.MkdirAll(f, 0000)
 				t.Cleanup(func() {
 					os.Chmod(f, 0755)
@@ -191,6 +193,21 @@ func TestRmDryRunCommand(t *testing.T) {
 			cmdutil.CommandRunner = commandRunner
 			if tc.cmdRun != nil {
 				cmdutil.CommandRunner = tc.cmdRun
+			}
+
+			var runErr error
+			_, _, err := capture(func() {
+				a := newApp()
+				args := append([]string{"ghq"}, tc.input...)
+				runErr = a.Run(context.Background(), args)
+			})
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if gotErr := runErr != nil; gotErr != tc.expectErr {
+				t.Fatalf("error = %v, expectErr = %v", runErr, tc.expectErr)
 			}
 		})
 	}

--- a/cmd_rm_test.go
+++ b/cmd_rm_test.go
@@ -41,19 +41,25 @@ func TestRmCommand(t *testing.T) {
 			name:  "simple",
 			input: []string{"rm", "motemen/ghqq"},
 			setup: func(t *testing.T) {
-				f := filepath.Join(tmpd, "github.com", "motemen", "ghqq", "README.md")
-				if err := os.MkdirAll(filepath.Dir(f), 0755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.WriteFile(f, []byte("test"), 0644); err != nil {
+				if err := os.MkdirAll(filepath.Join(tmpd, "github.com", "motemen", "ghqq", ".git"), 0755); err != nil {
 					t.Fatal(err)
 				}
 			},
 			expectErr: false,
 		},
 		{
-			name:      "empty directory",
-			input:     []string{"rm", "motemen/ghqqq"},
+			name:  "empty directory",
+			input: []string{"rm", "motemen/ghqqq"},
+			setup: func(t *testing.T) {
+				if err := os.MkdirAll(filepath.Join(tmpd, "github.com", "motemen", "ghqqq"), 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name:      "missing directory",
+			input:     []string{"rm", "motemen/missing"},
 			setup:     func(t *testing.T) {},
 			expectErr: true,
 		},

--- a/cmd_rm_test.go
+++ b/cmd_rm_test.go
@@ -41,7 +41,13 @@ func TestRmCommand(t *testing.T) {
 			name:  "simple",
 			input: []string{"rm", "motemen/ghqq"},
 			setup: func(t *testing.T) {
-				os.MkdirAll(filepath.Join(tmpd, "github.com", "motemen", "ghqq"), 0755)
+				f := filepath.Join(tmpd, "github.com", "motemen", "ghqq", "README.md")
+				if err := os.MkdirAll(filepath.Dir(f), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(f, []byte("test"), 0644); err != nil {
+					t.Fatal(err)
+				}
 			},
 			expectErr: false,
 		},
@@ -86,6 +92,21 @@ func TestRmCommand(t *testing.T) {
 			cmdutil.CommandRunner = commandRunner
 			if tc.cmdRun != nil {
 				cmdutil.CommandRunner = tc.cmdRun
+			}
+
+			var runErr error
+			_, _, err := captureWithInput([]string{"y"}, func() {
+				a := newApp()
+				args := append([]string{"ghq"}, tc.input...)
+				runErr = a.Run(context.Background(), args)
+			})
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if gotErr := runErr != nil; gotErr != tc.expectErr {
+				t.Fatalf("error = %v, expectErr = %v", runErr, tc.expectErr)
 			}
 		})
 	}


### PR DESCRIPTION
 ## Summary

  This PR fixes the `ghq rm` test cases so they actually execute the command under test and assert whether it returns an error.

  Previously, the table-driven cases in `TestRmCommand` and `TestRmDryRunCommand` set up inputs and expected results, but did not call `a.Run`, so the cases were effectively no-ops. This made invalid cases such as missing
  repositories, empty directories, and permission errors unverified.

  ## Changes

  - Run `ghq rm` test cases through `a.Run`
  - Feed confirmation input for non-dry-run removal tests
  - Assert `expectErr` against the actual command result
  - Create `.git` directories for valid repository fixtures
  - Separate empty-directory and missing-directory cases
