### PR TITLE
feat: add ignore-host repository naming

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,11 +16,11 @@ You can also list local repositories (+ghq list+).
 == SYNOPSIS
 
 [verse]
-ghq get [-u] [-p] [--shallow] [--vcs <vcs>] [--look] [--silent] [--branch] [--no-recursive] [--bare] [--partial blobless|treeless] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
-ghq list [-p] [-e] [<query>]
-ghq create [--vcs <vcs>] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
-ghq rm [--dry-run] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
-ghq migrate [-y] [--dry-run] <local repository path>
+ghq get [-u] [-p] [--shallow] [--vcs <vcs>] [--look] [--silent] [--branch] [--no-recursive] [--bare] [--ignore-host] [--partial blobless|treeless] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
+ghq list [-p] [-e] [--ignore-host] [<query>]
+ghq create [--vcs <vcs>] [--ignore-host] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
+ghq rm [--dry-run] [--ignore-host] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
+ghq migrate [-y] [--dry-run] [--ignore-host] <local repository path>
 ghq root [--all]
 
 == COMMANDS
@@ -103,6 +103,20 @@ ghq.defaultHost::
     For example, `ghq get owner/project` normally resolves to `github.com/owner/project`.
     If this option is set, the specified host will be used instead.
 
+ghq.ignoreHost::
+    Store repositories without the host path component.
+    For example, `ghq get github.com/owner/project` is stored as `owner/project`
+    instead of `github.com/owner/project`.
+    This option can also be enabled per command with `--ignore-host`.
+    The default is `false`, which preserves the current host-prefixed layout.
++
+    WARNING: different remotes such as `github.com/owner/project` and
+    `gitlab.com/owner/project` collide under this mode because they map to the
+    same local path. ghq treats that as an error. Use `ghq migrate --ignore-host`
+    to move an existing repository into the hostless layout, and note that
+    `migrate` also refuses a source repository whose current host directory does
+    not match the repository remote host.
+
 ghq.<url>.vcs::
     ghq tries to detect the remote repository's VCS backend for non-"github.com"
     repositories.  With this option you can explicitly specify the VCS for the
@@ -135,6 +149,9 @@ GHQ_ROOT::
 == [[directory-structures]]DIRECTORY STRUCTURES
 
 Local repositories are placed under 'ghq.root' with named github.com/_user_/_repo_.
+
+When `ghq.ignoreHost` or `--ignore-host` is enabled, repositories are placed
+under 'ghq.root' without the leading host directory.
 
 ....
 ~/ghq

--- a/cmd_create.go
+++ b/cmd_create.go
@@ -16,6 +16,10 @@ func doCreate(ctx context.Context, cmd *cli.Command) error {
 		w    = cmd.Root().Writer
 		bare = cmd.Bool("bare")
 	)
+	ignoreHost, err := ignoreHostFromCommand(cmd)
+	if err != nil {
+		return err
+	}
 
 	if name == "" {
 		return fmt.Errorf("repository name is required")
@@ -26,7 +30,7 @@ func doCreate(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	localRepo, err := LocalRepositoryFromURL(u, bare)
+	localRepo, err := localRepositoryForURL(u, bare, ignoreHost)
 	if err != nil {
 		return err
 	}

--- a/cmd_create_test.go
+++ b/cmd_create_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Songmu/gitconfig"
 	"github.com/x-motemen/ghq/cmdutil"
 )
 
@@ -168,5 +169,88 @@ func TestDoCreate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDoCreateIgnoreHost(t *testing.T) {
+	defer func(orig func(cmd *exec.Cmd) error) {
+		cmdutil.CommandRunner = orig
+	}(cmdutil.CommandRunner)
+	defer func(orig string) { _home = orig }(_home)
+	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
+
+	_home = ""
+	homeOnce = &sync.Once{}
+	tmpd := newTempDir(t)
+	setEnv(t, envGhqRoot, tmpd)
+	_localRepositoryRoots = nil
+	localRepoOnce = &sync.Once{}
+
+	var lastCmd *exec.Cmd
+	cmdutil.CommandRunner = func(cmd *exec.Cmd) error {
+		lastCmd = cmd
+		return nil
+	}
+
+	var runErr error
+	out, _, err := capture(func() {
+		runErr = newApp().Run(context.Background(), []string{"ghq", "create", "--ignore-host", "motemen/ghq-ignore"})
+	})
+	if err != nil {
+		t.Fatalf("capture returned error: %v", err)
+	}
+	if runErr != nil {
+		t.Fatalf("create returned error: %v", runErr)
+	}
+
+	want := filepath.Join(tmpd, "motemen", "ghq-ignore")
+	if lastCmd == nil || lastCmd.Dir != want {
+		t.Fatalf("cmd.Dir = %q, want %q", lastCmd.Dir, want)
+	}
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("stdout = %q, want %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestDoCreateConfigIgnoreHost(t *testing.T) {
+	defer func(orig func(cmd *exec.Cmd) error) {
+		cmdutil.CommandRunner = orig
+	}(cmdutil.CommandRunner)
+	defer func(orig string) { _home = orig }(_home)
+	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
+
+	_home = ""
+	homeOnce = &sync.Once{}
+	tmpd := newTempDir(t)
+	setEnv(t, envGhqRoot, tmpd)
+	_localRepositoryRoots = nil
+	localRepoOnce = &sync.Once{}
+	t.Cleanup(gitconfig.WithConfig(t, `[ghq]
+ignoreHost = true
+`))
+
+	var lastCmd *exec.Cmd
+	cmdutil.CommandRunner = func(cmd *exec.Cmd) error {
+		lastCmd = cmd
+		return nil
+	}
+
+	var runErr error
+	out, _, err := capture(func() {
+		runErr = newApp().Run(context.Background(), []string{"ghq", "create", "motemen/ghq-config-ignore"})
+	})
+	if err != nil {
+		t.Fatalf("capture returned error: %v", err)
+	}
+	if runErr != nil {
+		t.Fatalf("create returned error: %v", runErr)
+	}
+
+	want := filepath.Join(tmpd, "motemen", "ghq-config-ignore")
+	if lastCmd == nil || lastCmd.Dir != want {
+		t.Fatalf("cmd.Dir = %q, want %q", lastCmd.Dir, want)
+	}
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("stdout = %q, want %q", strings.TrimSpace(out), want)
 	}
 }

--- a/cmd_get.go
+++ b/cmd_get.go
@@ -27,16 +27,21 @@ func doGet(ctx context.Context, cmd *cli.Command) error {
 		parallel = cmd.Bool("parallel")
 		silent   = cmd.Bool("silent")
 	)
+	ignoreHost, err := ignoreHostFromCommand(cmd)
+	if err != nil {
+		return err
+	}
 	g := &getter{
-		update:    cmd.Bool("update"),
-		shallow:   cmd.Bool("shallow"),
-		ssh:       cmd.Bool("p"),
-		vcs:       cmd.String("vcs"),
-		silent:    silent,
-		branch:    cmd.String("branch"),
-		recursive: !cmd.Bool("no-recursive"),
-		bare:      cmd.Bool("bare"),
-		partial:   cmd.String("partial"),
+		update:     cmd.Bool("update"),
+		shallow:    cmd.Bool("shallow"),
+		ssh:        cmd.Bool("p"),
+		vcs:        cmd.String("vcs"),
+		silent:     silent,
+		branch:     cmd.String("branch"),
+		recursive:  !cmd.Bool("no-recursive"),
+		bare:       cmd.Bool("bare"),
+		partial:    cmd.String("partial"),
+		ignoreHost: ignoreHost,
 	}
 	if parallel {
 		// force silent in parallel import
@@ -51,7 +56,6 @@ func doGet(ctx context.Context, cmd *cli.Command) error {
 		argCnt   int
 		getInfo  getInfo // For fetching and looking a single repo
 		scr      scanner
-		err      error
 	)
 	if len(args) > 0 {
 		scr = &sliceScanner{slice: args}
@@ -104,7 +108,7 @@ func doGet(ctx context.Context, cmd *cli.Command) error {
 	}
 	if andLook {
 		if argCnt > 1 && firstArg != "" {
-			return look(firstArg, g.bare)
+			return lookWithOption(firstArg, g.bare, g.ignoreHost)
 		}
 		if argCnt == 1 && getInfo.localRepository != nil {
 			return lookByLocalRepository(getInfo.localRepository)
@@ -149,6 +153,10 @@ func detectShell() string {
 }
 
 func look(name string, bare bool) error {
+	return lookWithOption(name, bare, false)
+}
+
+func lookWithOption(name string, bare, ignoreHost bool) error {
 	var (
 		reposFound []*LocalRepository
 		mu         sync.Mutex
@@ -165,7 +173,7 @@ func look(name string, bare bool) error {
 
 	if len(reposFound) == 0 {
 		if url, err := newURL(name, false, false); err == nil {
-			repo, err := LocalRepositoryFromURL(url, bare)
+			repo, err := lookupLocalRepositoryForURL(url, bare, ignoreHost)
 			if err != nil {
 				return err
 			}

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -21,6 +21,10 @@ func doList(ctx context.Context, cmd *cli.Command) error {
 		printUniquePaths = cmd.Bool("unique")
 		bare             = cmd.Bool("bare")
 	)
+	ignoreHost, err := ignoreHostFromCommand(cmd)
+	if err != nil {
+		return err
+	}
 
 	filterByQuery := func(_ *LocalRepository) bool {
 		return true
@@ -28,7 +32,7 @@ func doList(ctx context.Context, cmd *cli.Command) error {
 	if query != "" {
 		if hasSchemePattern.MatchString(query) || scpLikeURLPattern.MatchString(query) {
 			if url, err := newURL(query, false, false); err == nil {
-				if repo, err := LocalRepositoryFromURL(url, bare); err == nil {
+				if repo, err := lookupLocalRepositoryForURL(url, bare, ignoreHost); err == nil {
 					query = filepath.ToSlash(repo.RelPath)
 				}
 			}

--- a/cmd_migrate.go
+++ b/cmd_migrate.go
@@ -21,6 +21,10 @@ func doMigrate(ctx context.Context, cmd *cli.Command) error {
 		skipConfirm = cmd.Bool("y")
 		w           = cmd.Root().Writer
 	)
+	ignoreHost, err := ignoreHostFromCommand(cmd)
+	if err != nil {
+		return err
+	}
 
 	if repoDir == "" {
 		return fmt.Errorf("repository directory is required")
@@ -71,13 +75,47 @@ func doMigrate(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to parse remote URL %q: %w", remoteURL, err)
 	}
 
-	// Derive destination path
-	localRepo, err := LocalRepositoryFromURL(u, false)
+	srcRepo, err := MaybeLocalRepositoryFromFullPath(absDir, vcsBackend)
 	if err != nil {
-		return fmt.Errorf("failed to derive destination path: %w", err)
+		return fmt.Errorf("failed to resolve source repository location: %w", err)
 	}
 
-	destPath := localRepo.FullPath
+	var destPath string
+	if ignoreHost {
+		if srcRepo != nil && srcRepo.HasHostPathPrefix() && srcRepo.PathParts[0] != u.Hostname() {
+			return fmt.Errorf("source repository host root %q does not match remote host %q", srcRepo.PathParts[0], u.Hostname())
+		}
+
+		naming := repoNamingFromURL(u, false, true)
+		remoteURLStr := u.String()
+		if u.Scheme == "codecommit" {
+			remoteURLStr = u.Opaque
+		}
+		root, err := getRoot(remoteURLStr)
+		if err != nil {
+			return fmt.Errorf("failed to derive destination path: %w", err)
+		}
+		destPath = filepath.Join(root, naming.canonicalRelPath)
+
+		var conflicts []*LocalRepository
+		if err := walkAllLocalRepositories(func(repo *LocalRepository) {
+			if repo.HostlessRelPath() != naming.hostlessRelPath || (srcRepo != nil && repo.RelPath == srcRepo.RelPath) {
+				return
+			}
+			conflicts = append(conflicts, repo)
+		}); err != nil {
+			return fmt.Errorf("failed to derive destination path: %w", err)
+		}
+		if len(conflicts) > 0 {
+			return ignoreHostConflictError(naming.hostlessRelPath, conflicts)
+		}
+	} else {
+		localRepo, err := LocalRepositoryFromURL(u, false)
+		if err != nil {
+			return fmt.Errorf("failed to derive destination path: %w", err)
+		}
+		destPath = localRepo.FullPath
+	}
 
 	// Check if source and destination are the same
 	if absDir == destPath {

--- a/cmd_migrate_test.go
+++ b/cmd_migrate_test.go
@@ -77,6 +77,38 @@ func TestDoMigrate(t *testing.T) {
 		}
 	})
 
+	t.Run("migrate_success_ignore_host", func(t *testing.T) {
+		srcdir := initGitRepo(t, filepath.Join(tmpdir, "github.com", "alice", "proj-ignore"),
+			"https://github.com/alice/proj-ignore.git")
+
+		a := newApp()
+		e := a.Run(context.Background(), []string{"ghq", "migrate", "-y", "--ignore-host", srcdir})
+		if e != nil {
+			t.Fatal(e)
+		}
+
+		dest := filepath.Join(tmpdir, "alice", "proj-ignore")
+		if _, err := os.Stat(dest); os.IsNotExist(err) {
+			t.Error("dest not found")
+		}
+	})
+
+	t.Run("migrate_success_ignore_host_from_unmanaged_source", func(t *testing.T) {
+		srcdir := initGitRepo(t, filepath.Join(tmpdir, "external", "alice", "proj-unmanaged"),
+			"https://github.com/alice/proj-unmanaged.git")
+
+		a := newApp()
+		e := a.Run(context.Background(), []string{"ghq", "migrate", "-y", "--ignore-host", srcdir})
+		if e != nil {
+			t.Fatal(e)
+		}
+
+		dest := filepath.Join(tmpdir, "alice", "proj-unmanaged")
+		if _, err := os.Stat(dest); os.IsNotExist(err) {
+			t.Error("dest not found")
+		}
+	})
+
 	// Test case: nonexistent directory
 	t.Run("migrate_nonexist", func(t *testing.T) {
 		a := newApp()
@@ -267,6 +299,37 @@ func TestMigrateEdgeCases(t *testing.T) {
 		e := a.Run(context.Background(), []string{"ghq", "migrate", "-y", srcdir})
 		if e == nil {
 			t.Error("should fail when dest exists")
+		}
+	})
+
+	t.Run("ignore_host_rejects_mismatched_host_root", func(t *testing.T) {
+		srcdir := initGitRepo(t, filepath.Join(tmpdir, "gitlab.com", "alice", "wrong-host"),
+			"https://github.com/alice/wrong-host.git")
+
+		a := newApp()
+		e := a.Run(context.Background(), []string{"ghq", "migrate", "-y", "--ignore-host", srcdir})
+		if e == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(e.Error(), "does not match remote host") {
+			t.Fatalf("unexpected error: %v", e)
+		}
+	})
+
+	t.Run("ignore_host_rejects_colliding_repository", func(t *testing.T) {
+		srcdir := initGitRepo(t, filepath.Join(tmpdir, "github.com", "alice", "collision"),
+			"https://github.com/alice/collision.git")
+		if err := os.MkdirAll(filepath.Join(tmpdir, "gitlab.com", "alice", "collision", ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		a := newApp()
+		e := a.Run(context.Background(), []string{"ghq", "migrate", "-y", "--ignore-host", srcdir})
+		if e == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(e.Error(), "ignore-host naming collision") {
+			t.Fatalf("unexpected error: %v", e)
 		}
 	})
 

--- a/cmd_rm.go
+++ b/cmd_rm.go
@@ -18,6 +18,10 @@ func doRm(ctx context.Context, cmd *cli.Command) error {
 		w    = cmd.Root().Writer
 		bare = cmd.Bool("bare")
 	)
+	ignoreHost, err := ignoreHostFromCommand(cmd)
+	if err != nil {
+		return err
+	}
 
 	if name == "" {
 		return fmt.Errorf("repository name is required")
@@ -28,7 +32,7 @@ func doRm(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	localRepo, err := LocalRepositoryFromURL(u, bare)
+	localRepo, err := lookupLocalRepositoryForURL(u, bare, ignoreHost)
 	if err != nil {
 		return err
 	}

--- a/commands.go
+++ b/commands.go
@@ -41,6 +41,7 @@ var commandGet = &cli.Command{
 			Usage: "Specify `branch` name. This flag implies --single-branch on Git"},
 		&cli.BoolFlag{Name: "parallel", Aliases: []string{"P"}, Usage: "Import parallelly"},
 		&cli.BoolFlag{Name: "bare", Usage: "Do a bare clone"},
+		&cli.BoolFlag{Name: "ignore-host", Usage: "Ignore the repository host in local path naming"},
 		&cli.StringFlag{
 			Name:  "partial",
 			Usage: "Do a partial clone. Can specify either \"blobless\" or \"treeless\"",
@@ -70,6 +71,7 @@ var commandList = &cli.Command{
 		&cli.BoolFlag{Name: "full-path", Aliases: []string{"p"}, Usage: "Print full paths"},
 		&cli.BoolFlag{Name: "unique", Usage: "Print unique subpaths"},
 		&cli.BoolFlag{Name: "bare", Usage: "Query bare repositories"},
+		&cli.BoolFlag{Name: "ignore-host", Usage: "Ignore the repository host in local path naming"},
 	},
 }
 
@@ -80,6 +82,7 @@ var commandRm = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.BoolFlag{Name: "dry-run", Usage: "Do not remove actually"},
 		&cli.BoolFlag{Name: "bare", Usage: "Remove a bare repository"},
+		&cli.BoolFlag{Name: "ignore-host", Usage: "Ignore the repository host in local path naming"},
 	},
 }
 
@@ -99,6 +102,7 @@ var commandCreate = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "vcs", Usage: "Specify `vcs` backend explicitly"},
 		&cli.BoolFlag{Name: "bare", Usage: "Create a bare repository"},
+		&cli.BoolFlag{Name: "ignore-host", Usage: "Ignore the repository host in local path naming"},
 	},
 }
 
@@ -108,12 +112,12 @@ type commandDoc struct {
 }
 
 var commandDocs = map[string]commandDoc{
-	"get":     {"", "[-u] [-p] [--shallow] [--vcs <vcs>] [--look] [--silent] [--branch <branch>] [--no-recursive] [--bare] [--partial blobless|treeless] <repository URL>|<project>|<user>/<project>|<host>/<user>/<project>"},
-	"list":    {"", "[-p] [-e] [<query>]"},
-	"create":  {"", "<project>|<user>/<project>|<host>/<user>/<project>"},
-	"rm":      {"", "<project>|<user>/<project>|<host>/<user>/<project>"},
+	"get":     {"", "[-u] [-p] [--shallow] [--vcs <vcs>] [--look] [--silent] [--branch <branch>] [--no-recursive] [--bare] [--ignore-host] [--partial blobless|treeless] <repository URL>|<project>|<user>/<project>|<host>/<user>/<project>"},
+	"list":    {"", "[-p] [-e] [--ignore-host] [<query>]"},
+	"create":  {"", "[--ignore-host] <project>|<user>/<project>|<host>/<user>/<project>"},
+	"rm":      {"", "[--ignore-host] <project>|<user>/<project>|<host>/<user>/<project>"},
 	"root":    {"", "[-all]"},
-	"migrate": {"", "[-y] [--dry-run] <repository-directory>"},
+	"migrate": {"", "[-y] [--dry-run] [--ignore-host] <repository-directory>"},
 }
 
 // Makes template conditionals to generate per-command documents.
@@ -154,5 +158,6 @@ var commandMigrate = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.BoolFlag{Name: "y", Usage: "Skip confirmation prompt"},
 		&cli.BoolFlag{Name: "dry-run", Usage: "Show what would happen without moving"},
+		&cli.BoolFlag{Name: "ignore-host", Usage: "Ignore the repository host in local path naming"},
 	},
 }

--- a/getter.go
+++ b/getter.go
@@ -27,6 +27,7 @@ type getInfo struct {
 type getter struct {
 	update, shallow, silent, ssh, recursive, bare bool
 	vcs, branch, partial                          string
+	ignoreHost                                    bool
 }
 
 func (g *getter) get(ctx context.Context, argURL string) (getInfo, error) {
@@ -51,7 +52,7 @@ func (g *getter) get(ctx context.Context, argURL string) (getInfo, error) {
 // If isShallow is true, does shallow cloning. (no effect if already cloned or the VCS is Mercurial and git-svn)
 func (g *getter) getRemoteRepository(ctx context.Context, remote RemoteRepository, branch string) (getInfo, error) {
 	remoteURL := remote.URL()
-	local, err := LocalRepositoryFromURL(remoteURL, g.bare)
+	local, err := localRepositoryForURL(remoteURL, g.bare, g.ignoreHost)
 	if err != nil {
 		return getInfo{}, err
 	}
@@ -94,7 +95,14 @@ func (g *getter) getRemoteRepository(ctx context.Context, remote RemoteRepositor
 			}
 		}
 		if l := detectLocalRepoRoot(remoteURL.Path, repoURL.Path); l != "" {
-			localRepoRoot = filepath.Join(local.RootPath, remoteURL.Hostname(), l)
+			rootParts := []string{local.RootPath}
+			if g.ignoreHost {
+				rootParts = append(rootParts, splitRepoPath(l)...)
+			} else {
+				rootParts = append(rootParts, remoteURL.Hostname())
+				rootParts = append(rootParts, splitRepoPath(l)...)
+			}
+			localRepoRoot = filepath.Join(rootParts...)
 		}
 
 		if g.bare {

--- a/local_repository.go
+++ b/local_repository.go
@@ -72,53 +72,19 @@ func LocalRepositoryFromFullPath(fullPath string, backend *VCSBackend) (*LocalRe
 	}, nil
 }
 
+// MaybeLocalRepositoryFromFullPath resolves a managed local repository from a file path.
+// If the path is not under any ghq-managed root, it returns (nil, nil).
+func MaybeLocalRepositoryFromFullPath(fullPath string, backend *VCSBackend) (*LocalRepository, error) {
+	repo, err := LocalRepositoryFromFullPath(fullPath, backend)
+	if err != nil && strings.HasPrefix(err.Error(), "no local repository found for: ") {
+		return nil, nil
+	}
+	return repo, err
+}
+
 // LocalRepositoryFromURL resolve LocalRepository from URL
 func LocalRepositoryFromURL(remoteURL *url.URL, bare bool) (*LocalRepository, error) {
-	pathParts := append(
-		[]string{remoteURL.Hostname()}, strings.Split(remoteURL.Path, "/")...,
-	)
-	relPath := strings.TrimSuffix(filepath.Join(pathParts...), ".git")
-	pathParts[len(pathParts)-1] = strings.TrimSuffix(pathParts[len(pathParts)-1], ".git")
-	if bare {
-		// Force to append ".git" even if remoteURL does not end with ".git".
-		relPath = relPath + ".git"
-		pathParts[len(pathParts)-1] = pathParts[len(pathParts)-1] + ".git"
-	}
-
-	var (
-		localRepository *LocalRepository
-		mu              sync.Mutex
-	)
-	// Find existing local repository first
-	if err := walkAllLocalRepositories(func(repo *LocalRepository) {
-		if repo.RelPath == relPath {
-			mu.Lock()
-			localRepository = repo
-			mu.Unlock()
-		}
-	}); err != nil {
-		return nil, err
-	}
-
-	if localRepository != nil {
-		return localRepository, nil
-	}
-	var remoteURLStr = remoteURL.String()
-	if remoteURL.Scheme == "codecommit" {
-		remoteURLStr = remoteURL.Opaque
-	}
-	prim, err := getRoot(remoteURLStr)
-	if err != nil {
-		return nil, err
-	}
-
-	// No local repository found, returning new one
-	return &LocalRepository{
-		FullPath:  filepath.Join(prim, relPath),
-		RelPath:   relPath,
-		RootPath:  prim,
-		PathParts: pathParts,
-	}, nil
+	return localRepositoryForURL(remoteURL, bare, false)
 }
 
 func getRoot(u string) (string, error) {
@@ -156,7 +122,20 @@ func (repo *LocalRepository) Subpaths() []string {
 
 // NonHostPath returns non host path
 func (repo *LocalRepository) NonHostPath() string {
-	return strings.Join(repo.PathParts[1:], "/")
+	return repo.HostlessRelPath()
+}
+
+// HostlessRelPath returns the repository path without the host prefix when present.
+func (repo *LocalRepository) HostlessRelPath() string {
+	if repo.HasHostPathPrefix() {
+		return strings.Join(repo.PathParts[1:], "/")
+	}
+	return strings.Join(repo.PathParts, "/")
+}
+
+// HasHostPathPrefix reports whether the path begins with a host directory.
+func (repo *LocalRepository) HasHostPathPrefix() bool {
+	return len(repo.PathParts) >= 3 && looksLikeAuthorityPattern.MatchString(repo.PathParts[0])
 }
 
 // list as bellow
@@ -164,12 +143,10 @@ func (repo *LocalRepository) NonHostPath() string {
 // - "$GHQ_ROOT/github.com/motemen/ghq"
 // - "$GHQ_ROOT/github.com/motemen
 func (repo *LocalRepository) repoRootCandidates() []string {
-	hostRoot := filepath.Join(repo.RootPath, repo.PathParts[0])
-	nonHostParts := repo.PathParts[1:]
-	candidates := make([]string, len(nonHostParts))
-	for i := range nonHostParts {
+	candidates := make([]string, len(repo.PathParts))
+	for i := range repo.PathParts {
 		candidates[i] = filepath.Join(append(
-			[]string{hostRoot}, nonHostParts[0:len(nonHostParts)-i]...)...)
+			[]string{repo.RootPath}, repo.PathParts[0:len(repo.PathParts)-i]...)...)
 	}
 	return candidates
 }

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -134,6 +134,59 @@ func TestNewLocalRepository(t *testing.T) {
 	}
 }
 
+func TestLocalRepositoryForURLIgnoreHost(t *testing.T) {
+	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
+	tmproot := newTempDir(t)
+	_localRepositoryRoots = []string{tmproot}
+
+	repo, err := localRepositoryForURL(mustParseURL("https://github.com/motemen/ghq.git"), false, true)
+	if err != nil {
+		t.Fatalf("localRepositoryForURL returned error: %v", err)
+	}
+
+	want := filepath.Join(tmproot, "motemen", "ghq")
+	if repo.FullPath != want {
+		t.Fatalf("FullPath = %q, want %q", repo.FullPath, want)
+	}
+	if repo.RelPath != "motemen/ghq" {
+		t.Fatalf("RelPath = %q, want %q", repo.RelPath, "motemen/ghq")
+	}
+}
+
+func TestLocalRepositoryForURLIgnoreHostCollision(t *testing.T) {
+	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
+	tmproot := newTempDir(t)
+	_localRepositoryRoots = []string{tmproot}
+
+	if err := os.MkdirAll(filepath.Join(tmproot, "gitlab.com", "motemen", "ghq", ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := localRepositoryForURL(mustParseURL("https://github.com/motemen/ghq.git"), false, true)
+	if err == nil || !strings.Contains(err.Error(), "ignore-host naming collision") {
+		t.Fatalf("expected ignore-host collision error, got: %v", err)
+	}
+}
+
+func TestLookupLocalRepositoryForURLIgnoreHostFindsLegacyLayout(t *testing.T) {
+	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
+	tmproot := newTempDir(t)
+	_localRepositoryRoots = []string{tmproot}
+
+	legacy := filepath.Join(tmproot, "github.com", "motemen", "ghq")
+	if err := os.MkdirAll(filepath.Join(legacy, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repo, err := lookupLocalRepositoryForURL(mustParseURL("https://github.com/motemen/ghq.git"), false, true)
+	if err != nil {
+		t.Fatalf("lookupLocalRepositoryForURL returned error: %v", err)
+	}
+	if repo.FullPath != legacy {
+		t.Fatalf("FullPath = %q, want %q", repo.FullPath, legacy)
+	}
+}
+
 func TestLocalRepositoryRoots(t *testing.T) {
 	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
 

--- a/naming.go
+++ b/naming.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/Songmu/gitconfig"
+	"github.com/urfave/cli/v3"
+)
+
+const configIgnoreHost = "ghq.ignoreHost"
+
+type repoNaming struct {
+	ignoreHost       bool
+	hostfulRelPath   string
+	hostlessRelPath  string
+	canonicalRelPath string
+	hostfulParts     []string
+	hostlessParts    []string
+	canonicalParts   []string
+}
+
+func ignoreHostFromCommand(cmd *cli.Command) (bool, error) {
+	if cmd.Bool("ignore-host") {
+		return true, nil
+	}
+
+	ignoreHost, err := gitconfig.Bool(configIgnoreHost)
+	if err != nil {
+		if gitconfig.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return ignoreHost, nil
+}
+
+func newRepoNaming(remoteURL *url.URL, bare, ignoreHost bool) repoNaming {
+	repoParts := splitRepoPath(remoteURL.Path)
+	if len(repoParts) > 0 {
+		repoParts[len(repoParts)-1] = strings.TrimSuffix(repoParts[len(repoParts)-1], ".git")
+	}
+
+	hostlessParts := append([]string(nil), repoParts...)
+	hostfulParts := append([]string{remoteURL.Hostname()}, repoParts...)
+	if bare {
+		if len(hostlessParts) > 0 {
+			hostlessParts[len(hostlessParts)-1] = hostlessParts[len(hostlessParts)-1] + ".git"
+		}
+		if len(hostfulParts) > 0 {
+			hostfulParts[len(hostfulParts)-1] = hostfulParts[len(hostfulParts)-1] + ".git"
+		}
+	}
+
+	canonicalParts := hostfulParts
+	canonicalRelPath := relPathFromParts(hostfulParts)
+	if ignoreHost {
+		canonicalParts = hostlessParts
+		canonicalRelPath = relPathFromParts(hostlessParts)
+	}
+
+	return repoNaming{
+		ignoreHost:       ignoreHost,
+		hostfulRelPath:   relPathFromParts(hostfulParts),
+		hostlessRelPath:  relPathFromParts(hostlessParts),
+		canonicalRelPath: canonicalRelPath,
+		hostfulParts:     hostfulParts,
+		hostlessParts:    hostlessParts,
+		canonicalParts:   canonicalParts,
+	}
+}
+
+func splitRepoPath(urlPath string) []string {
+	trimmed := strings.Trim(urlPath, "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
+}
+
+func relPathFromParts(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Join(parts...))
+}
+
+func repoNamingFromURL(remoteURL *url.URL, bare, ignoreHost bool) repoNaming {
+	return newRepoNaming(remoteURL, bare, ignoreHost)
+}
+
+func newLocalRepositoryFromNaming(remoteURL *url.URL, naming repoNaming, root string) *LocalRepository {
+	return &LocalRepository{
+		FullPath:  filepath.Join(root, naming.canonicalRelPath),
+		RelPath:   naming.canonicalRelPath,
+		RootPath:  root,
+		PathParts: append([]string(nil), naming.canonicalParts...),
+	}
+}
+
+func localRepositoryForURL(remoteURL *url.URL, bare, ignoreHost bool) (*LocalRepository, error) {
+	naming := repoNamingFromURL(remoteURL, bare, ignoreHost)
+	match, err := findCanonicalRepositoryMatch(remoteURL, naming)
+	if err != nil {
+		return nil, err
+	}
+	if match != nil {
+		return match, nil
+	}
+
+	remoteURLStr := remoteURL.String()
+	if remoteURL.Scheme == "codecommit" {
+		remoteURLStr = remoteURL.Opaque
+	}
+	root, err := getRoot(remoteURLStr)
+	if err != nil {
+		return nil, err
+	}
+	return newLocalRepositoryFromNaming(remoteURL, naming, root), nil
+}
+
+func lookupLocalRepositoryForURL(remoteURL *url.URL, bare, ignoreHost bool) (*LocalRepository, error) {
+	naming := repoNamingFromURL(remoteURL, bare, ignoreHost)
+	if !ignoreHost {
+		match, err := findCanonicalRepositoryMatch(remoteURL, naming)
+		if err != nil {
+			return nil, err
+		}
+		if match != nil {
+			return match, nil
+		}
+		remoteURLStr := remoteURL.String()
+		if remoteURL.Scheme == "codecommit" {
+			remoteURLStr = remoteURL.Opaque
+		}
+		root, err := getRoot(remoteURLStr)
+		if err != nil {
+			return nil, err
+		}
+		return newLocalRepositoryFromNaming(remoteURL, naming, root), nil
+	}
+
+	var (
+		exact   *LocalRepository
+		matches []*LocalRepository
+	)
+	if err := walkAllLocalRepositories(func(repo *LocalRepository) {
+		if repo.HostlessRelPath() != naming.hostlessRelPath {
+			return
+		}
+		if repo.RelPath == naming.canonicalRelPath {
+			exact = repo
+		}
+		matches = append(matches, repo)
+	}); err != nil {
+		return nil, err
+	}
+
+	if exact != nil {
+		ok, err := repoMatchesRemoteHost(exact, remoteURL)
+		if err == nil && !ok {
+			return nil, ignoreHostConflictError(naming.hostlessRelPath, matches)
+		}
+		if len(matches) == 1 {
+			return exact, nil
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		remoteURLStr := remoteURL.String()
+		if remoteURL.Scheme == "codecommit" {
+			remoteURLStr = remoteURL.Opaque
+		}
+		root, err := getRoot(remoteURLStr)
+		if err != nil {
+			return nil, err
+		}
+		return newLocalRepositoryFromNaming(remoteURL, naming, root), nil
+	case 1:
+		return matches[0], nil
+	default:
+		return nil, ignoreHostConflictError(naming.hostlessRelPath, matches)
+	}
+}
+
+func findCanonicalRepositoryMatch(remoteURL *url.URL, naming repoNaming) (*LocalRepository, error) {
+	var (
+		exact      *LocalRepository
+		collisions []*LocalRepository
+	)
+
+	if err := walkAllLocalRepositories(func(repo *LocalRepository) {
+		if repo.RelPath == naming.canonicalRelPath {
+			exact = repo
+		}
+		if naming.ignoreHost && repo.HostlessRelPath() == naming.hostlessRelPath && repo.RelPath != naming.canonicalRelPath {
+			collisions = append(collisions, repo)
+		}
+	}); err != nil {
+		return nil, err
+	}
+
+	if !naming.ignoreHost {
+		return exact, nil
+	}
+
+	if exact != nil {
+		ok, err := repoMatchesRemoteHost(exact, remoteURL)
+		if err == nil {
+			if !ok {
+				return nil, ignoreHostConflictError(naming.hostlessRelPath, []*LocalRepository{exact})
+			}
+		} else if len(collisions) == 0 {
+			return exact, nil
+		}
+	}
+
+	if len(collisions) > 0 {
+		return nil, ignoreHostConflictError(naming.hostlessRelPath, collisions)
+	}
+
+	return exact, nil
+}
+
+func repoMatchesRemoteHost(repo *LocalRepository, remoteURL *url.URL) (bool, error) {
+	vcs, repoPath := repo.VCS()
+	if vcs == nil || vcs.RemoteURL == nil {
+		return false, fmt.Errorf("cannot determine remote host for %q", repo.RelPath)
+	}
+
+	remote, err := vcs.RemoteURL(repoPath)
+	if err != nil {
+		return false, err
+	}
+
+	u, err := newURL(remote, false, false)
+	if err != nil {
+		return false, err
+	}
+
+	return u.Hostname() == remoteURL.Hostname(), nil
+}
+
+func ignoreHostConflictError(hostlessRelPath string, repos []*LocalRepository) error {
+	paths := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		paths = append(paths, repo.RelPath)
+	}
+	return fmt.Errorf("ignore-host naming collision for %q; existing repositories use the same owner/repo path: %s. Migrate or remove the conflicting repository first", hostlessRelPath, strings.Join(paths, ", "))
+}


### PR DESCRIPTION
## Summary
- add --ignore-host and ghq.ignoreHost to support owner/repo local naming while keeping the current host-based default
- centralize repository path resolution and apply it across get, create, list, rm, and migrate
- reject hostless naming collisions and make migrate enforce host-root consistency when moving managed repositories

## Testing
- GOCACHE=/tmp/ghq-go-build-cache GOMODCACHE=/tmp/ghq-go-mod-cache go test ./...