### PR TITLE
Group Dependabot updates for golang.org/x and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "actions/*"


### PR DESCRIPTION
Group related Dependabot updates into single pull requests to reduce noise:

- **gomod**: bundle `golang.org/x/*` module updates into a `golang-x` group.
- **github-actions**: bundle official `actions/*` updates into an `actions` group.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>