### PR TITLE
docs: mention clone.defaultRemoteName

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -117,6 +117,10 @@ ghq.<url>.root::
     you can specify a repository-specific root directory instead of the common ghq root directory. +
     The URL is matched against '<url>' using 'git config --get-urlmatch'.
 
+Since `ghq get` runs `git clone` for Git repositories, git's own configuration applies as
+well. For example, `clone.defaultRemoteName` changes the name of the created remote, which
+is `origin` by default. +
+To get this configuration variable effective, you will need Git 2.30 or higher.
 
 === Example configuration (.gitconfig):
 


### PR DESCRIPTION
Refs #427.

`ghq get` clones via `git`, so git's own `clone.defaultRemoteName` already lets you change the name of the created remote. It just wasn't documented, so it hasn't come up.