### PR TITLE
feat(get): add --clean-bare flag for clean bare-repo layout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ You can also list local repositories (+ghq list+).
 == SYNOPSIS
 
 [verse]
-ghq get [-u] [-p] [--shallow] [--vcs <vcs>] [--look] [--silent] [--branch] [--no-recursive] [--bare] [--partial blobless|treeless] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
+ghq get [-u] [-p] [--shallow] [--vcs <vcs>] [--look] [--silent] [--branch] [--no-recursive] [--bare] [--clean-bare] [--partial blobless|treeless] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
 ghq list [-p] [-e] [<query>]
 ghq create [--vcs <vcs>] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
 ghq rm [--dry-run] <repository URL>|<host>/<user>/<project>|<user>/<project>|<project>
@@ -45,7 +45,25 @@ get::
     The 'ghq' gets the git repository recursively by default. +
     We can prevent it with '--no-recursive' option.
     With '--bare' option, a "bare clone" will be performed (for Git
-    repositories only, 'git clone --bare ...' eg.). +
+    repositories only, 'git clone --bare ...' eg.). The on-disk directory
+    receives a '.git' suffix (e.g. '<root>/host/user/repo.git'). +
+    With '--clean-bare' option, a bare clone is performed but the bare
+    gitdir is placed as a '.git' subdirectory of an unsuffixed parent
+    (e.g. '<root>/host/user/repo/.git'). This layout keeps the repository
+    directory name clean and allows Git worktrees to live as sibling
+    subdirectories:
++
+....
+repo/
+├── .git/       # bare repository
+├── main/       # worktree
+├── feature/    # worktree
+└── bugfix/     # worktree
+....
++
+'--clean-bare' implies '--bare'. Passing both together is not an error:
+'--bare' is ignored (with a warning) and the clone follows the
+'--clean-bare' layout. +
     With '--partial' option, a "partial clone" will be performed (for Git
     repositories only, in 'blobless' mode, 'git clone --filter=blob:none ...',
     in 'treeless' mode, 'git clone --filter=tree:0 ...' eg.).

--- a/cmd_create.go
+++ b/cmd_create.go
@@ -26,7 +26,7 @@ func doCreate(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	localRepo, err := LocalRepositoryFromURL(u, bare)
+	localRepo, err := LocalRepositoryFromURL(u, bareModeFromClassicBool(bare))
 	if err != nil {
 		return err
 	}

--- a/cmd_get.go
+++ b/cmd_get.go
@@ -22,11 +22,26 @@ import (
 
 func doGet(ctx context.Context, cmd *cli.Command) error {
 	var (
-		args     = cmd.Args().Slice()
-		andLook  = cmd.Bool("look")
-		parallel = cmd.Bool("parallel")
-		silent   = cmd.Bool("silent")
+		args      = cmd.Args().Slice()
+		andLook   = cmd.Bool("look")
+		parallel  = cmd.Bool("parallel")
+		silent    = cmd.Bool("silent")
+		bare      = cmd.Bool("bare")
+		cleanBare = cmd.Bool("clean-bare")
 	)
+	// --clean-bare implies --bare. When both are set the intent is
+	// unambiguous but the classic --bare is redundant; emit a warning
+	// so users don't get silently different behavior than they typed.
+	if bare && cleanBare {
+		logger.Log("warning", "--bare is redundant when --clean-bare is set; ignoring --bare")
+	}
+	bareMode := BareNone
+	switch {
+	case cleanBare:
+		bareMode = BareClean
+	case bare:
+		bareMode = BareClassic
+	}
 	g := &getter{
 		update:    cmd.Bool("update"),
 		shallow:   cmd.Bool("shallow"),
@@ -35,7 +50,7 @@ func doGet(ctx context.Context, cmd *cli.Command) error {
 		silent:    silent,
 		branch:    cmd.String("branch"),
 		recursive: !cmd.Bool("no-recursive"),
-		bare:      cmd.Bool("bare"),
+		bareMode:  bareMode,
 		partial:   cmd.String("partial"),
 	}
 	if parallel {
@@ -104,7 +119,7 @@ func doGet(ctx context.Context, cmd *cli.Command) error {
 	}
 	if andLook {
 		if argCnt > 1 && firstArg != "" {
-			return look(firstArg, g.bare)
+			return look(firstArg, g.bareMode)
 		}
 		if argCnt == 1 && getInfo.localRepository != nil {
 			return lookByLocalRepository(getInfo.localRepository)
@@ -148,7 +163,7 @@ func detectShell() string {
 	return "/bin/sh"
 }
 
-func look(name string, bare bool) error {
+func look(name string, mode BareMode) error {
 	var (
 		reposFound []*LocalRepository
 		mu         sync.Mutex
@@ -165,7 +180,7 @@ func look(name string, bare bool) error {
 
 	if len(reposFound) == 0 {
 		if url, err := newURL(name, false, false); err == nil {
-			repo, err := LocalRepositoryFromURL(url, bareModeFromClassicBool(bare))
+			repo, err := LocalRepositoryFromURL(url, mode)
 			if err != nil {
 				return err
 			}

--- a/cmd_get.go
+++ b/cmd_get.go
@@ -165,7 +165,7 @@ func look(name string, bare bool) error {
 
 	if len(reposFound) == 0 {
 		if url, err := newURL(name, false, false); err == nil {
-			repo, err := LocalRepositoryFromURL(url, bare)
+			repo, err := LocalRepositoryFromURL(url, bareModeFromClassicBool(bare))
 			if err != nil {
 				return err
 			}

--- a/cmd_get_test.go
+++ b/cmd_get_test.go
@@ -223,6 +223,70 @@ func TestCommandGet(t *testing.T) {
 			}
 		},
 	}, {
+		name: "clean-bare",
+		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+			localDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo", ".git")
+
+			app.Run(context.Background(), []string{"", "get", "--clean-bare", "motemen/ghq-test-repo"})
+
+			expect := "https://github.com/motemen/ghq-test-repo"
+			if cloneArgs.remote.String() != expect {
+				t.Errorf("got: %s, expect: %s", cloneArgs.remote, expect)
+			}
+			if filepath.ToSlash(cloneArgs.local) != filepath.ToSlash(localDir) {
+				t.Errorf("got: %s, expect: %s", filepath.ToSlash(cloneArgs.local), filepath.ToSlash(localDir))
+			}
+			// --clean-bare implies --bare at the git-invocation layer:
+			// the resulting repo must be a bare git repository.
+			if !cloneArgs.bare {
+				t.Errorf("cloneArgs.bare should be true (--clean-bare implies --bare)")
+			}
+		},
+	}, {
+		name: "bare and clean-bare together (clean-bare wins, warns on --bare)",
+		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+			localDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo", ".git")
+
+			// --clean-bare implies --bare; passing both should emit a
+			// warning and still perform a clean-bare clone. We do not
+			// assert on the warning text here because logger output is
+			// bound to the original os.Stderr at package init and does
+			// not follow the test's stderr redirection reliably.
+			app.Run(context.Background(), []string{"", "get", "--bare", "--clean-bare", "motemen/ghq-test-repo"})
+
+			expect := "https://github.com/motemen/ghq-test-repo"
+			if cloneArgs.remote.String() != expect {
+				t.Errorf("got: %s, expect: %s", cloneArgs.remote, expect)
+			}
+			// When both flags are set, --clean-bare must control the layout.
+			if filepath.ToSlash(cloneArgs.local) != filepath.ToSlash(localDir) {
+				t.Errorf("got: %s, expect: %s (clean-bare must win over bare)", filepath.ToSlash(cloneArgs.local), filepath.ToSlash(localDir))
+			}
+			if !cloneArgs.bare {
+				t.Errorf("cloneArgs.bare should be true")
+			}
+		},
+	}, {
+		name: "already cloned clean-bare with -update",
+		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
+			// Clean-bare layout: repo/ with a .git subdirectory that is
+			// itself a bare gitdir. Path resolution treats this as a
+			// normal-looking repo; the update path must still target the
+			// parent (not the .git subdir) and pass bare=true to the VCS
+			// backend so it invokes the bare-repo fetch codepath.
+			parentDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo")
+			os.MkdirAll(filepath.Join(parentDir, ".git"), 0755)
+
+			app.Run(context.Background(), []string{"", "get", "--clean-bare", "-update", "motemen/ghq-test-repo"})
+
+			if filepath.ToSlash(updateArgs.local) != filepath.ToSlash(parentDir) {
+				t.Errorf("updateArgs.local got: %s, expect: %s", filepath.ToSlash(updateArgs.local), filepath.ToSlash(parentDir))
+			}
+			if !updateArgs.bare {
+				t.Errorf("updateArgs.bare should be true (--clean-bare implies --bare)")
+			}
+		},
+	}, {
 		name: "silent mode",
 		scenario: func(t *testing.T, tmpRoot string, cloneArgs *_cloneArgs, updateArgs *_updateArgs) {
 			localDir := filepath.Join(tmpRoot, "github.com", "motemen", "ghq-test-repo")
@@ -437,13 +501,13 @@ func TestLook(t *testing.T) {
 			t.Errorf("lastCmd.Env[len(lastCmd.Env)-1]: got: %s, expect: %s", gotEnv, expectEnv)
 		}
 
-		err = look("github.com/motemen/_unknown", false)
+		err = look("github.com/motemen/_unknown", BareNone)
 		expect := "no repository found"
 		if !strings.HasPrefix(fmt.Sprintf("%s", err), expect) {
 			t.Errorf("error should has prefix %q, but: %s", expect, err)
 		}
 
-		err = look("gobump", false)
+		err = look("gobump", BareNone)
 		expect = "More than one repositories are found; Try more precise name"
 		if !strings.HasPrefix(fmt.Sprintf("%s", err), expect) {
 			t.Errorf("error should has prefix %q, but: %s", expect, err)
@@ -483,13 +547,13 @@ func TestBareLook(t *testing.T) {
 			t.Errorf("lastCmd.Env[len(lastCmd.Env)-1]: got: %s, expect: %s", gotEnv, expectEnv)
 		}
 
-		err = look("github.com/motemen/ghq", false)
+		err = look("github.com/motemen/ghq", BareNone)
 		expect := "no repository found"
 		if !strings.HasPrefix(fmt.Sprintf("%s", err), expect) {
 			t.Errorf("error should has prefix %q, but: %s", expect, err)
 		}
 
-		err = look("github.com/motemen/gobump.git", true)
+		err = look("github.com/motemen/gobump.git", BareClassic)
 		expect = "no repository found"
 		if !strings.HasPrefix(fmt.Sprintf("%s", err), expect) {
 			t.Errorf("error should has prefix %q, but: %s", expect, err)

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -28,7 +28,7 @@ func doList(ctx context.Context, cmd *cli.Command) error {
 	if query != "" {
 		if hasSchemePattern.MatchString(query) || scpLikeURLPattern.MatchString(query) {
 			if url, err := newURL(query, false, false); err == nil {
-				if repo, err := LocalRepositoryFromURL(url, bare); err == nil {
+				if repo, err := LocalRepositoryFromURL(url, bareModeFromClassicBool(bare)); err == nil {
 					query = filepath.ToSlash(repo.RelPath)
 				}
 			}

--- a/cmd_migrate.go
+++ b/cmd_migrate.go
@@ -72,7 +72,7 @@ func doMigrate(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// Derive destination path
-	localRepo, err := LocalRepositoryFromURL(u, false)
+	localRepo, err := LocalRepositoryFromURL(u, BareNone)
 	if err != nil {
 		return fmt.Errorf("failed to derive destination path: %w", err)
 	}

--- a/cmd_rm.go
+++ b/cmd_rm.go
@@ -28,7 +28,7 @@ func doRm(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	localRepo, err := LocalRepositoryFromURL(u, bare)
+	localRepo, err := LocalRepositoryFromURL(u, bareModeFromClassicBool(bare))
 	if err != nil {
 		return err
 	}

--- a/commands.go
+++ b/commands.go
@@ -41,6 +41,7 @@ var commandGet = &cli.Command{
 			Usage: "Specify `branch` name. This flag implies --single-branch on Git"},
 		&cli.BoolFlag{Name: "parallel", Aliases: []string{"P"}, Usage: "Import parallelly"},
 		&cli.BoolFlag{Name: "bare", Usage: "Do a bare clone"},
+		&cli.BoolFlag{Name: "clean-bare", Usage: "Do a clean bare clone (bare gitdir as a .git subdirectory of the repo directory). Implies --bare."},
 		&cli.StringFlag{
 			Name:  "partial",
 			Usage: "Do a partial clone. Can specify either \"blobless\" or \"treeless\"",

--- a/commands_test.go
+++ b/commands_test.go
@@ -20,6 +20,7 @@ type _cloneArgs struct {
 
 type _updateArgs struct {
 	local string
+	bare  bool
 }
 
 func withFakeGitBackend(t *testing.T, block func(*testing.T, string, *_cloneArgs, *_updateArgs)) {
@@ -49,6 +50,7 @@ func withFakeGitBackend(t *testing.T, block func(*testing.T, string, *_cloneArgs
 		Update: func(vg *vcsGetOption) error {
 			updateArgs = _updateArgs{
 				local: vg.dir,
+				bare:  vg.bare,
 			}
 			return nil
 		},

--- a/getter.go
+++ b/getter.go
@@ -25,8 +25,9 @@ type getInfo struct {
 }
 
 type getter struct {
-	update, shallow, silent, ssh, recursive, bare bool
-	vcs, branch, partial                          string
+	update, shallow, silent, ssh, recursive bool
+	bareMode                                BareMode
+	vcs, branch, partial                    string
 }
 
 func (g *getter) get(ctx context.Context, argURL string) (getInfo, error) {
@@ -51,7 +52,7 @@ func (g *getter) get(ctx context.Context, argURL string) (getInfo, error) {
 // If isShallow is true, does shallow cloning. (no effect if already cloned or the VCS is Mercurial and git-svn)
 func (g *getter) getRemoteRepository(ctx context.Context, remote RemoteRepository, branch string) (getInfo, error) {
 	remoteURL := remote.URL()
-	local, err := LocalRepositoryFromURL(remoteURL, bareModeFromClassicBool(g.bare))
+	local, err := LocalRepositoryFromURL(remoteURL, g.bareMode)
 	if err != nil {
 		return getInfo{}, err
 	}
@@ -97,7 +98,19 @@ func (g *getter) getRemoteRepository(ctx context.Context, remote RemoteRepositor
 			localRepoRoot = filepath.Join(local.RootPath, remoteURL.Hostname(), l)
 		}
 
-		if g.bare {
+		// localRepoRoot at this point does NOT include the bare-mode
+		// suffix (detectLocalRepoRoot strips ".git" if present); the
+		// switch below adds it (either as a suffix on the leaf directory
+		// or as a ".git" subdirectory).
+		switch g.bareMode {
+		case BareClean:
+			// Clean-bare: the bare gitdir lives inside the leaf directory
+			// as ".git" (repo/.git), so we join rather than concatenate.
+			localRepoRoot = filepath.Join(localRepoRoot, ".git")
+		case BareClassic:
+			// Classic bare: the leaf directory itself is the bare gitdir
+			// (repo -> repo.git), so we suffix the leaf and deliberately
+			// do NOT use filepath.Join, which would create a new segment.
 			localRepoRoot = localRepoRoot + ".git"
 		}
 
@@ -113,7 +126,7 @@ func (g *getter) getRemoteRepository(ctx context.Context, remote RemoteRepositor
 					silent:    g.silent,
 					branch:    branch,
 					recursive: g.recursive,
-					bare:      g.bare,
+					bare:      g.bareMode != BareNone,
 					partial:   g.partial,
 				})
 		}
@@ -134,7 +147,7 @@ func (g *getter) getRemoteRepository(ctx context.Context, remote RemoteRepositor
 				dir:       localRepoRoot,
 				silent:    g.silent,
 				recursive: g.recursive,
-				bare:      g.bare,
+				bare:      g.bareMode != BareNone,
 			})
 		}
 		return info, nil

--- a/getter.go
+++ b/getter.go
@@ -51,7 +51,7 @@ func (g *getter) get(ctx context.Context, argURL string) (getInfo, error) {
 // If isShallow is true, does shallow cloning. (no effect if already cloned or the VCS is Mercurial and git-svn)
 func (g *getter) getRemoteRepository(ctx context.Context, remote RemoteRepository, branch string) (getInfo, error) {
 	remoteURL := remote.URL()
-	local, err := LocalRepositoryFromURL(remoteURL, g.bare)
+	local, err := LocalRepositoryFromURL(remoteURL, bareModeFromClassicBool(g.bare))
 	if err != nil {
 		return getInfo{}, err
 	}

--- a/local_repository.go
+++ b/local_repository.go
@@ -72,14 +72,47 @@ func LocalRepositoryFromFullPath(fullPath string, backend *VCSBackend) (*LocalRe
 	}, nil
 }
 
+// BareMode selects the on-disk layout of a bare-cloned repository.
+// It is used by LocalRepositoryFromURL to decide how (or whether) the
+// ".git" suffix appears in the resolved path. The illegal state
+// "bare with no known layout" is unrepresentable by construction.
+type BareMode int
+
+const (
+	// BareNone represents a normal (non-bare) clone. The on-disk path
+	// matches the repository name with no ".git" suffix
+	// (e.g. "<root>/host/user/repo").
+	BareNone BareMode = iota
+	// BareClassic represents the classic bare layout, where the on-disk
+	// directory name itself gets a ".git" suffix
+	// (e.g. "<root>/host/user/repo.git").
+	BareClassic
+	// BareClean represents the "clean bare" layout, where the bare gitdir
+	// lives as a ".git" subdirectory of an unsuffixed parent
+	// (e.g. "<root>/host/user/repo/.git"). From ghq's path-resolution
+	// perspective this is indistinguishable from BareNone; the ".git"
+	// subdirectory is created by the git backend at clone time.
+	BareClean
+)
+
+// bareModeFromClassicBool is a compatibility helper for commands that
+// expose only the classic --bare flag (list, rm, create, migrate).
+// It returns BareClassic when bare is true, otherwise BareNone.
+func bareModeFromClassicBool(bare bool) BareMode {
+	if bare {
+		return BareClassic
+	}
+	return BareNone
+}
+
 // LocalRepositoryFromURL resolve LocalRepository from URL
-func LocalRepositoryFromURL(remoteURL *url.URL, bare bool) (*LocalRepository, error) {
+func LocalRepositoryFromURL(remoteURL *url.URL, mode BareMode) (*LocalRepository, error) {
 	pathParts := append(
 		[]string{remoteURL.Hostname()}, strings.Split(remoteURL.Path, "/")...,
 	)
 	relPath := strings.TrimSuffix(filepath.Join(pathParts...), ".git")
 	pathParts[len(pathParts)-1] = strings.TrimSuffix(pathParts[len(pathParts)-1], ".git")
-	if bare {
+	if mode == BareClassic {
 		// Force to append ".git" even if remoteURL does not end with ".git".
 		relPath = relPath + ".git"
 		pathParts[len(pathParts)-1] = pathParts[len(pathParts)-1] + ".git"

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -134,6 +134,68 @@ func TestNewLocalRepository(t *testing.T) {
 	}
 }
 
+func TestLocalRepositoryFromURL_BareMode(t *testing.T) {
+	defer func(orig []string) { _localRepositoryRoots = orig }(_localRepositoryRoots)
+	tmproot := newTempDir(t)
+	_localRepositoryRoots = []string{tmproot}
+
+	testCases := []struct {
+		name    string
+		url     string
+		mode    BareMode
+		expect  string
+		relPath string
+	}{{
+		name:    "normal (BareNone)",
+		url:     "ssh://git@github.com/motemen/ghq.git",
+		mode:    BareNone,
+		expect:  filepath.Join(tmproot, "github.com/motemen/ghq"),
+		relPath: filepath.FromSlash("github.com/motemen/ghq"),
+	}, {
+		name:    "classic bare",
+		url:     "ssh://git@github.com/motemen/ghq.git",
+		mode:    BareClassic,
+		expect:  filepath.Join(tmproot, "github.com/motemen/ghq.git"),
+		relPath: filepath.FromSlash("github.com/motemen/ghq.git"),
+	}, {
+		name:    "classic bare with URL missing .git suffix",
+		url:     "ssh://git@github.com/motemen/ghq",
+		mode:    BareClassic,
+		expect:  filepath.Join(tmproot, "github.com/motemen/ghq.git"),
+		relPath: filepath.FromSlash("github.com/motemen/ghq.git"),
+	}, {
+		name:    "clean bare",
+		url:     "ssh://git@github.com/motemen/ghq.git",
+		mode:    BareClean,
+		expect:  filepath.Join(tmproot, "github.com/motemen/ghq"),
+		relPath: filepath.FromSlash("github.com/motemen/ghq"),
+	}, {
+		name:    "clean bare with URL missing .git suffix",
+		url:     "ssh://git@github.com/motemen/ghq",
+		mode:    BareClean,
+		expect:  filepath.Join(tmproot, "github.com/motemen/ghq"),
+		relPath: filepath.FromSlash("github.com/motemen/ghq"),
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func(orig string) { _home = orig }(_home)
+			_home = ""
+			homeOnce = &sync.Once{}
+			r, err := LocalRepositoryFromURL(mustParseURL(tc.url), tc.mode)
+			if err != nil {
+				t.Fatalf("error should be nil but: %s", err)
+			}
+			if r.FullPath != tc.expect {
+				t.Errorf("FullPath got: %s, expect: %s", r.FullPath, tc.expect)
+			}
+			if r.RelPath != tc.relPath {
+				t.Errorf("RelPath got: %s, expect: %s", r.RelPath, tc.relPath)
+			}
+		})
+	}
+}
+
 func TestBareModeFromClassicBool(t *testing.T) {
 	if bareModeFromClassicBool(true) != BareClassic {
 		t.Errorf("bareModeFromClassicBool(true) = %d, want BareClassic (%d)", bareModeFromClassicBool(true), BareClassic)

--- a/local_repository_test.go
+++ b/local_repository_test.go
@@ -123,7 +123,7 @@ func TestNewLocalRepository(t *testing.T) {
 			defer func(orig string) { _home = orig }(_home)
 			_home = ""
 			homeOnce = &sync.Once{}
-			r, err := LocalRepositoryFromURL(mustParseURL(tc.url), false)
+			r, err := LocalRepositoryFromURL(mustParseURL(tc.url), BareNone)
 			if err != nil {
 				t.Errorf("error should be nil but: %s", err)
 			}
@@ -131,6 +131,15 @@ func TestNewLocalRepository(t *testing.T) {
 				t.Errorf("got: %s, expect: %s", r.FullPath, tc.expect)
 			}
 		})
+	}
+}
+
+func TestBareModeFromClassicBool(t *testing.T) {
+	if bareModeFromClassicBool(true) != BareClassic {
+		t.Errorf("bareModeFromClassicBool(true) = %d, want BareClassic (%d)", bareModeFromClassicBool(true), BareClassic)
+	}
+	if bareModeFromClassicBool(false) != BareNone {
+		t.Errorf("bareModeFromClassicBool(false) = %d, want BareNone (%d)", bareModeFromClassicBool(false), BareNone)
 	}
 }
 

--- a/vcs.go
+++ b/vcs.go
@@ -152,6 +152,13 @@ var GitBackend = &VCSBackend{
 	},
 	Init: func(dir string) error {
 		args := []string{"init"}
+		// TODO(clean-bare): this HasSuffix check coincidentally works for
+		// classic bare (dir ends with ".git") but would misfire for the
+		// clean-bare layout, where dir is <root>/host/user/repo and the
+		// bare gitdir needs to be created inside it as ".git". If ghq
+		// create ever grows a --clean-bare flag, this decision needs an
+		// explicit signal (e.g. a bare/mode argument through the Init
+		// signature) rather than reading it off the path shape.
 		if strings.HasSuffix(dir, ".git") {
 			args = append(args, "--bare")
 		}


### PR DESCRIPTION
Fixes #420

## Problem

`ghq get --bare` clones into `<root>/host/user/repo.git`, appending `.git`
to the directory name. Tools that create git worktrees from bare repos
(e.g. [Worktrunk](https://worktrunk.dev), git-wt) produce awkward
sibling paths like `repo.git.main/` or `repo.git.feature/`.

The widely-adopted "clean bare" pattern clones into
`<root>/host/user/repo/.git`, keeping the repo directory name clean and
allowing worktrees to live as subdirectories:

```
repo/
├── .git/       # bare repository
├── main/       # worktree
├── feature/    # worktree
└── bugfix/     # worktree
```

References:

- [Morgan Cugerone: How to use git worktree (clean way)](https://morgan.cugerone.com/blog/how-to-use-git-worktree-and-in-a-clean-way)
- [Worktrunk: Bare repository layout](https://worktrunk.dev/tips-patterns/#bare-repository-layout)

## Solution

A new `--clean-bare` flag on `ghq get`:

```
ghq get --clean-bare github.com/user/repo
# → <root>/github.com/user/repo/.git   (bare)
```

`--clean-bare` implies `--bare` at the git-invocation layer (the resulting
gitdir is still a bare repository); it only changes where that gitdir
lands on disk. Passing both `--bare` and `--clean-bare` is not an error:
`--bare` is ignored (with a stderr warning) and the clone follows the
`--clean-bare` layout.

## Commits

1. **refactor: introduce BareMode for LocalRepositoryFromURL** —
   replaces the `bare bool` parameter with a `BareMode` enum
   (`BareNone`, `BareClassic`, `BareClean`) via a
   `bareModeFromClassicBool` helper. No behavior change.
2. **feat(get): add --clean-bare flag for clean bare-repo layout** —
   adds the flag, threads `BareMode` through `getter` and `look`, and
   adjusts path construction in `LocalRepositoryFromURL` +
   `getter.getRemoteRepository`.
3. **test: cover BareMode and --clean-bare in ghq get** —
   `TestLocalRepositoryFromURL_BareMode` covering all three modes across
   `.git`-suffixed and unsuffixed URL forms; new `TestCommandGet`
   subtests for `--clean-bare`, the `--bare + --clean-bare` precedence,
   and `--clean-bare --update` (locking in the "update targets parent
   dir with `bare=true`" contract).
4. **docs: document --clean-bare in README.adoc** — synopsis + prose
   paragraph with the layout ASCII tree and precedence rule.

## Scope

Intentionally out of scope (deferred to a follow-up, tracked separately):

- `ghq list --bare <url>`, `ghq rm --bare <url>`, `ghq create --bare`
  do **not** grow a `--clean-bare` flag. Clean-bare repos are already
  discoverable via `ghq list <url>` (without `--bare`) because they
  present the same on-disk shape as normal clones. Symmetric
  `--clean-bare` support on those commands is worth a separate
  discussion — see the follow-up issue linked under **Future work**.
- `GitBackend.Init` uses `strings.HasSuffix(dir, ".git")` to decide
  `--bare`. This works coincidentally for classic bare but would need
  an explicit signal if `--clean-bare` is ever extended to `ghq create`.
  A `TODO(clean-bare):` comment marks the site.

## Test coverage

- `LocalRepositoryFromURL` returns the correct `FullPath`/`RelPath` for
  each `BareMode`, across `.git`-suffixed and unsuffixed URLs.
- `--clean-bare` semantic: clone target is `<parent>/.git` with
  `bare=true` passed to the VCS backend.
- Precedence: `--bare --clean-bare` clones into the clean-bare layout.
- `--clean-bare --update` on an existing clean-bare repo targets the
  parent directory with `bare=true`, matching git's own gitdir
  discovery.
- Existing `--bare` scenarios remain green.

Manually verified against `github.com/octocat/Hello-World`:

- `ghq get --clean-bare <url>` produces a working bare repo at `repo/.git`.
- `git worktree add repo/main master` from within the layout works.
- `ghq get --clean-bare --update <url>` fetches correctly.
- URLs with and without `.git` suffix produce identical on-disk results.

## Future work

Symmetric `--clean-bare` support for `ghq list`, `ghq rm`, and
`ghq create` is tracked separately<!--- at TODO(link-follow-up-issue)-->.

## Bonus alignment note

`worktree.go`'s `hasLinkedWorktrees` / `listLinkedWorktreePaths` helpers
look for `<dir>/.git/worktrees/…` (documented at
[`worktree.go:68-70`](../blob/master/worktree.go#L68-L70) as
missing worktrees under classic `--bare` layouts, which store them at
`<repo.git>/worktrees/`). The clean-bare layout at `repo/.git/worktrees/…`
matches the existing hardcoded lookup path, so `ghq rm` / `ghq migrate`
detect linked worktrees correctly for clean-bare repos without any
additional code changes.
